### PR TITLE
Make Date Conversion Overridable

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "bugs": {
     "url": "https://github.com/DavidDuwaer/coloquent/issues"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/lib/index.js",
+  "types": "dist/lib/index.d.ts",
   "scripts": {
     "prepublish": "npm run build",
     "build": "tsc",
@@ -36,7 +36,6 @@
     "@types/es6-promise": "0.0.32",
     "@types/moxios": "^0.4.8",
     "axios": "^0.16.2",
-    "php-date-formatter": "^1.3.4"
   },
   "devDependencies": {
     "@types/chai": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@types/es6-promise": "0.0.32",
     "@types/moxios": "^0.4.8",
-    "axios": "^0.16.2",
+    "axios": "^0.16.2"
   },
   "devDependencies": {
     "@types/chai": "^4.0.3",


### PR DESCRIPTION
- removed php-date-formater
- changed model dates param to arrray
- implement and use asDateTime

This PR will allow to do:

```
import {Model} from 'coloquent';
import moment from 'moment';

export default class AppModel extends Model
{
    asDateTime(value) {
        return moment(value);
    }
}
```

```
import AppModel from  './AppModel';

export default class Post extends AppModel
{
    constructor() {
        super();
        this.dates = ['published_at'];
    }

    getJsonApiType() {
        return 'posts';
    }

    getPrettyDate() {
        return this.getAttribute('published_at').format('MMMM Do YYYY'); // February 4th 2018
    }

    getHumanizedDate() {
        return this.getAttribute('published_at').humanize(); // 2 days ago
    }
}
```

by default coloquent will cast dates to Date objects and it will allow to:

```
getPrettyDate() {
     return this.getAttribute('published_at').toDateString(); // Sun Feb 04 2018
}
```