### PR TITLE
Allow both string and integer values in the find() static method.

### DIFF
--- a/lib/Builder.ts
+++ b/lib/Builder.ts
@@ -92,7 +92,7 @@ export class Builder implements QueryMethods
             );
     }
 
-    public find(id: number): Promise<SingularResponse>
+    public find(id: string | number): Promise<SingularResponse>
     {
         this.query.setIdToFind(id);
         let thiss = this;

--- a/lib/Builder.ts
+++ b/lib/Builder.ts
@@ -49,14 +49,13 @@ export class Builder implements QueryMethods
 
     public get(page: number = 0): Promise<Response>
     {
-        let thiss = this;
         this.query.getPaginationSpec().setPage(page);
         if (this.forceSingular) {
             return <Promise<SingularResponse>> this.getHttpClient()
                 .get(this.query.toString())
                 .then(
-                    function (response: HttpClientResponse) {
-                        return new SingularResponse(response, thiss.modelType, response.getData());
+                    (response: HttpClientResponse) => {
+                        return new SingularResponse(response, this.modelType, response.getData());
                     },
                     function (response: AxiosError) {
                         throw new Error(response.message);
@@ -66,8 +65,8 @@ export class Builder implements QueryMethods
             return <Promise<PluralResponse>> this.getHttpClient()
                 .get(this.query.toString())
                 .then(
-                    function (response: HttpClientResponse) {
-                        return new PluralResponse(response, thiss.modelType, response.getData(), page);
+                    (response: HttpClientResponse) => {
+                        return new PluralResponse(response, this.modelType, response.getData(), page);
                     },
                     function (response: AxiosError) {
                         throw new Error(response.message);
@@ -78,13 +77,12 @@ export class Builder implements QueryMethods
 
     public first(): Promise<SingularResponse>
     {
-        let thiss = this;
         this.query.getPaginationSpec().setPageLimit(1);
         return <Promise<SingularResponse>> this.getHttpClient()
             .get(this.query.toString())
             .then(
-                function (response: HttpClientResponse) {
-                    return new SingularResponse(response, thiss.modelType, response.getData());
+                (response: HttpClientResponse) => {
+                    return new SingularResponse(response, this.modelType, response.getData());
                 },
                 function (response: AxiosError) {
                     throw new Error(response.message);
@@ -95,12 +93,11 @@ export class Builder implements QueryMethods
     public find(id: string | number): Promise<SingularResponse>
     {
         this.query.setIdToFind(id);
-        let thiss = this;
         return <Promise<SingularResponse>> this.getHttpClient()
             .get(this.query.toString())
             .then(
-                function (response: HttpClientResponse) {
-                    return new SingularResponse(response, thiss.modelType, response.getData());
+                (response: HttpClientResponse) => {
+                    return new SingularResponse(response, this.modelType, response.getData());
                 },
                 function (response: AxiosError) {
                     throw new Error(response.message);

--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -127,7 +127,6 @@ export abstract class Model
 
     public save(): Promise<SaveResponse>
     {
-        let thiss = this;
         let attributes = {};
         for (let key in this.attributes.toArray()) {
             if (this.readOnlyAttributes.indexOf(key) == -1) {
@@ -148,9 +147,9 @@ export abstract class Model
                     payload
                 )
                 .then(
-                    function (response: HttpClientResponse) {
-                        thiss.setApiId(response.getData().data.id);
-                        return new SaveResponse(response, thiss.constructor, response.getData());
+                    (response: HttpClientResponse) => {
+                        this.setApiId(response.getData().data.id);
+                        return new SaveResponse(response, this.constructor, response.getData());
                     },
                     function (response: AxiosError) {
                         throw new Error(response.message);
@@ -163,9 +162,9 @@ export abstract class Model
                     payload
                 )
                 .then(
-                    function (response: HttpClientResponse) {
-                        thiss.setApiId(response.getData().data.id);
-                        return new SaveResponse(response, thiss.constructor, response.getData());
+                    (response: HttpClientResponse) => {
+                        this.setApiId(response.getData().data.id);
+                        return new SaveResponse(response, this.constructor, response.getData());
                     },
                     function (response: AxiosError) {
                         throw new Error(response.message);
@@ -176,7 +175,6 @@ export abstract class Model
 
     public create(): Promise<SaveResponse>
     {
-        let thiss = this;
         let attributes = {};
         for (let key in this.attributes.toArray()) {
             if (this.readOnlyAttributes.indexOf(key) == -1) {
@@ -198,9 +196,9 @@ export abstract class Model
                 payload
             )
             .then(
-                function (response: HttpClientResponse) {
-                    thiss.setApiId(response.getData().data.id);
-                    return new SaveResponse(response, thiss.constructor, response.getData());
+                (response: HttpClientResponse) => {
+                    this.setApiId(response.getData().data.id);
+                    return new SaveResponse(response, this.constructor, response.getData());
                 },
                 function (response: AxiosError) {
                     throw new Error(response.message);

--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -2,7 +2,7 @@ import {Builder} from "./Builder";
 import {JsonApiDoc} from "./JsonApiDoc";
 import {Map} from "./util/Map";
 import {AxiosInstance, AxiosPromise, AxiosResponse, AxiosError} from "axios";
-import axios from 'axios';
+import axios from "axios";
 import {PluralResponse} from "./response/PluralResponse";
 import {SingularResponse} from "./response/SingularResponse";
 import {PaginationStrategy} from "./PaginationStrategy";
@@ -95,7 +95,7 @@ export abstract class Model
             .first();
     }
 
-    public static find(id: number): Promise<SingularResponse>
+    public static find(id: string | number): Promise<SingularResponse>
     {
         return new Builder(this)
             .find(id);

--- a/lib/Query.ts
+++ b/lib/Query.ts
@@ -12,7 +12,7 @@ export class Query
 
     protected queriedRelationName: string;
 
-    protected idToFind: number;
+    protected idToFind: string | number;
 
     protected paginationSpec: PaginationSpec;
 
@@ -120,7 +120,7 @@ export class Query
         return this.jsonApiType + relationToFind + idToFind + paramString;
     }
 
-    public setIdToFind(idToFind: number): void
+    public setIdToFind(idToFind: string | number): void
     {
         this.idToFind = idToFind;
     }

--- a/lib/QueryMethods.ts
+++ b/lib/QueryMethods.ts
@@ -9,7 +9,7 @@ export interface QueryMethods
 
     first(): Promise<SingularResponse>;
 
-    find(id: number | string): Promise<SingularResponse>;
+    find(id: string | number ): Promise<SingularResponse>;
 
     where(attribute: string, value: string): Builder;
 

--- a/lib/QueryMethods.ts
+++ b/lib/QueryMethods.ts
@@ -1,5 +1,4 @@
 import {Builder} from "./Builder";
-import {PluralResponse} from "./response/PluralResponse";
 import {SingularResponse} from "./response/SingularResponse";
 import {Response} from "./response/Response";
 

--- a/lib/QueryMethods.ts
+++ b/lib/QueryMethods.ts
@@ -9,7 +9,7 @@ export interface QueryMethods
 
     first(): Promise<SingularResponse>;
 
-    find(id: number): Promise<SingularResponse>;
+    find(id: number | string): Promise<SingularResponse>;
 
     where(attribute: string, value: string): Builder;
 

--- a/lib/relation/ToManyRelation.ts
+++ b/lib/relation/ToManyRelation.ts
@@ -16,7 +16,7 @@ export class ToManyRelation extends Relation implements QueryMethods
             .first();
     }
 
-    find(id: number): Promise<SingularResponse> {
+    find(id: string | number): Promise<SingularResponse> {
         return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType())
             .find(id);
     }

--- a/lib/relation/ToOneRelation.ts
+++ b/lib/relation/ToOneRelation.ts
@@ -16,7 +16,7 @@ export class ToOneRelation extends Relation implements QueryMethods
             .first();
     }
 
-    find(id: number): Promise<SingularResponse> {
+    find(id: string | number): Promise<SingularResponse> {
         return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), true)
             .find(id);
     }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/es6-promise": "0.0.32",
     "@types/moxios": "^0.4.8",
     "axios": "^0.16.2",
+    "npm": "^5.8.0",
     "php-date-formatter": "^1.3.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@types/es6-promise": "0.0.32",
     "@types/moxios": "^0.4.8",
     "axios": "^0.16.2",
-    "npm": "^5.8.0",
     "php-date-formatter": "^1.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Allow both string and number type in Model::find() method, since unique slugs can be used as ID in JSON:API as well as numeric IDs.

Replaced some functions with narrow functions to deal with 'this' binding where it makes sense.