### PR TITLE
Check if id is undefined or empty string instead of null

### DIFF
--- a/src/Model.ts
+++ b/src/Model.ts
@@ -161,7 +161,7 @@ export abstract class Model
 
     public save(): Promise<SaveResponse>
     {
-        if (this.id === null) {
+        if (this.id === undefined || this.id === '') {
             return this.create();
         }
 


### PR DESCRIPTION
When we create a new model like below:

```js
let user = new User();
await user.save();
```
Coloquent will fire a `PATCH` call instead of a `POST` because the id has not been set and is still `undefined`. But we check for `null` when saving (the id can't be set to null).

This pull request will check for `undefined` and `''` to fix this issue.