### PR TITLE
Throw the response object with all data inside

### DIFF
--- a/src/Model.ts
+++ b/src/Model.ts
@@ -176,8 +176,8 @@ export abstract class Model
                     this.setApiId(response.getData().data.id);
                     return new SaveResponse(response, this.constructor, response.getData());
                 },
-                function (response: AxiosError) {
-                    throw new Error((<Error> response).message);
+                (response: AxiosError) => {
+                    throw response;
                 }
             );
     }


### PR DESCRIPTION
This pull request will throw the entire response object instead of the response message. 

This way we can use the response object to retrieve the errors from the errors object in the JSON API error response.