### PR TITLE
Ignore unimplemented relations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coloquent",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/response/RetrievalResponse.ts
+++ b/src/response/RetrievalResponse.ts
@@ -83,6 +83,9 @@ export abstract class RetrievalResponse extends Response
         model.populateFromResource(doc);
         this.modelIndex.get(type).set(id, model);
         for (let relationName in {...includeTree, ...doc.relationships}) {
+            if (model[relationName] === undefined) {
+                continue;
+            }
             const includeSubtree = includeTree[relationName];
             let relation: Relation = model[relationName]();
             if (relation instanceof ToManyRelation) {
@@ -128,9 +131,10 @@ export abstract class RetrievalResponse extends Response
     {
         this.included = [];
         for (let doc of includedDocs) {
-            this.included.push(
-                this.modelIndex.get(doc.type).get(doc.id)
-            );
+            const models = this.modelIndex.get(doc.type);
+            if (models !== undefined) {
+                this.included.push(models.get(doc.id));
+            }
         }
     }
 }

--- a/tests/RetrievalResponse.test.ts
+++ b/tests/RetrievalResponse.test.ts
@@ -134,4 +134,89 @@ describe('RetrievalResponse', () => {
             })
         });
     });
+
+
+    it('should not throw an exception but ignore discovered relations that are not implemented in the models', (done) => {
+        model.foes()
+            .with('foes')
+            .get()
+            .then((response: PluralResponse) => {
+                let beefMan: Hero = <Hero> response.getData()[0];
+
+                done();
+            })
+            .catch((err) => {
+                // it should not come here
+                assert.isTrue(false);
+                done();
+            });
+
+        moxios.wait(() => {
+            let request = moxios.requests.mostRecent();
+            request.respondWith({
+                response: {
+                    data: [
+                        {
+                            type: "heroes",
+                            id: "1",
+                            attributes: {
+                                name: "BeefMan"
+                            },
+                            relationships: {
+                                foes: {
+                                    data: [
+                                        {
+                                            type: "heroes",
+                                            id: "3"
+                                        }
+                                    ]
+                                },
+                                sidekicks: {
+                                    data: [
+                                        {
+                                            type: "sidekicks",
+                                            id: "1",
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            type: "heroes",
+                            id: "2",
+                            attributes: {
+                                name: "CarrotMan"
+                            },
+                            relationships: {
+                                foes: {
+                                    data: [
+                                        {
+                                            type: "heroes",
+                                            id: "3"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                    ],
+                    included: [
+                        {
+                            type: "heroes",
+                            id: "3",
+                            attributes: {
+                                name: "EggplantMan"
+                            }
+                        },
+                        {
+                            type: "sidekicks",
+                            id: "1",
+                            attributes: {
+                                name: "BurgerBoy"
+                            }
+                        }
+                    ]
+                }
+            });
+        });
+    });
 });


### PR DESCRIPTION
Users will no longer have to implement every relation that is returned form the API. Now applications will no longer break if the API developers decide to add more relations.