### PR TITLE
Throw the entire AxiosError instead of only its message

### DIFF
--- a/src/Model.ts
+++ b/src/Model.ts
@@ -198,7 +198,7 @@ export abstract class Model
                     return new SaveResponse(response, this.constructor, response.getData());
                 },
                 function (response: AxiosError) {
-                    throw new Error((<Error> response).message);
+                    throw response;
                 }
             );
     }


### PR DESCRIPTION
The entire AxiosError is now thrown just like in the save method of Model