### PR TITLE
Check if includeTree is available or it will return the default value

### DIFF
--- a/src/response/RetrievalResponse.ts
+++ b/src/response/RetrievalResponse.ts
@@ -86,7 +86,7 @@ export abstract class RetrievalResponse extends Response
             if (model[relationName] === undefined) {
                 continue;
             }
-            const includeSubtree = includeTree[relationName];
+            const includeSubtree = includeTree ? includeTree[relationName] : {};
             let relation: Relation = model[relationName]();
             if (relation instanceof ToManyRelation) {
                 let relatedStubs: ResourceStub[] = (doc.relationships !== undefined && doc.relationships[relationName] !== undefined)


### PR DESCRIPTION
This pull request will allow the valid JSON API syntax (https://jsonapi.org/format/#document-resource-object-linkage)

```json
"relationships": {
    "locks": {
            "data": []
        }
    },
}
```