### PR TITLE
Allow serialization of toMany relations

### DIFF
--- a/src/Model.ts
+++ b/src/Model.ts
@@ -139,14 +139,11 @@ export abstract class Model
         }
         let relationships = {};
         for (let key in this.relations.toArray()) {
-            let model = this.relations.get(key);
-            if (model instanceof Model) {
-                relationships[key] = {
-                    data: {
-                        type: model.getJsonApiType(),
-                        id: model.id
-                    }
-                };
+            let relation = this.relations.get(key);
+            if (relation instanceof Model) {
+                relationships[key] = this.serializeToOneRelation(relation);
+            } else if (relation instanceof Array && relation.length > 0) {
+                relationships[key] = this.serializeToManyRelation(relation);
             }
         }
 
@@ -161,6 +158,25 @@ export abstract class Model
             payload['data']['id'] = this.id;
         }
         return payload;
+    }
+
+    private serializeRelatedModel(model: Model): any {
+        return {
+            type: model.getJsonApiType(),
+            id: model.id
+        };
+    }
+
+    private serializeToOneRelation(model: Model): any {
+        return {
+            data: this.serializeRelatedModel(model),
+        }
+    }
+
+    private serializeToManyRelation(models: Model[]) {
+        return {
+            data: models.map((model) => this.serializeRelatedModel(model))
+        };
     }
 
     public save(): Promise<SaveResponse>

--- a/tests/model1/Model.test.ts
+++ b/tests/model1/Model.test.ts
@@ -218,4 +218,52 @@ describe('Model1', () => {
             done();
         });
     });
+
+    it('serializes a toOne relation when saving', (done) => {
+        const hero = new Hero();
+        hero.setName('MeatMan');
+
+        const rival = new Hero();
+        rival.setApiId(Math.floor(Math.random()*10000).toString());
+
+        hero.setRelation('rival', rival);
+        hero.save();
+
+        moxios.wait(() => {
+            const request = moxios.requests.mostRecent();
+            const requestBody = JSON.parse(request.config.data);
+            const relationships = requestBody.data.relationships;
+
+            expect(relationships.rival.data).to.be.an('object');
+            expect(relationships.rival.data.id).to.equal(rival.getApiId());
+            done();
+        })
+    });
+
+    it('serializes a toMany relation when saving', (done) => {
+        const hero = new Hero();
+        hero.setName('MeatMan');
+
+        const friendA = new Hero();
+        friendA.setApiId(Math.floor(Math.random()*10000).toString());
+
+        const friendB = new Hero();
+        friendB.setApiId(Math.floor(Math.random()*10000).toString());
+
+        hero.setRelation('friends', [friendA, friendB]);
+        hero.save();
+
+        moxios.wait(() => {
+            const request = moxios.requests.mostRecent();
+            const requestBody = JSON.parse(request.config.data);
+            const relationships = requestBody.data.relationships;
+
+            expect(relationships.friends.data).to.be.an('Array');
+            expect(relationships.friends.data.length).to.equal(2);
+            expect(relationships.friends.data[0].id).to.equal(friendA.getApiId());
+            expect(relationships.friends.data[1].id).to.equal(friendB.getApiId());
+
+            done();
+        });
+    });
 });

--- a/tests/model1/dummy/Hero.ts
+++ b/tests/model1/dummy/Hero.ts
@@ -1,5 +1,5 @@
 import {BaseModel} from './BaseModel';
-import {ToManyRelation} from "../../../dist";
+import {ToManyRelation, ToOneRelation} from "../../../dist";
 
 export class Hero extends BaseModel
 {
@@ -15,9 +15,19 @@ export class Hero extends BaseModel
         return this.hasMany(Hero, 'enemies');
     }
 
+    public rival(): ToOneRelation
+    {
+        return this.hasOne(Hero);
+    }
+
     public getName(): string
     {
         return this.getAttribute('name');
+    }
+
+    public setName(name: string): void
+    {
+        this.setAttribute('name', name);
     }
 
     public getFoes(): Hero[]


### PR DESCRIPTION
Allow users to store to many relations.

Before it only serialized toOne relations. I adjusted the code to also allow toMany relations to be serialized.