### PR TITLE
Use JSON-API compliance relationships URL

### DIFF
--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -33,6 +33,7 @@ export class Builder implements QueryMethods
         modelType: typeof Model,
         queriedRelationName: string | undefined = undefined,
         baseModelJsonApiType: string | undefined = undefined,
+        baseModelJsonApiId: string | undefined = undefined,
         forceSingular: boolean = false
     ) {
         this.modelType = modelType;
@@ -40,7 +41,7 @@ export class Builder implements QueryMethods
         baseModelJsonApiType = baseModelJsonApiType
             ? baseModelJsonApiType
             : modelInstance.getJsonApiType();
-        this.query = new Query(baseModelJsonApiType, queriedRelationName);
+        this.query = new Query(baseModelJsonApiType, queriedRelationName, baseModelJsonApiId);
         this.initPaginationSpec();
         this.httpClient = modelType.getHttpClient();
         this.forceSingular = forceSingular;

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -9,6 +9,8 @@ export class Query
 {
     protected jsonApiType: string;
 
+    protected jsonApiId: string | undefined;
+
     protected queriedRelationName: string | undefined;
 
     protected idToFind: string | number;
@@ -23,9 +25,10 @@ export class Query
 
     protected sort: SortSpec[];
 
-    constructor(jsonApiType: string, queriedRelationName: string | undefined = undefined)
+    constructor(jsonApiType: string, queriedRelationName: string | undefined = undefined, jsonApiId: string | undefined = undefined)
     {
         this.jsonApiType = jsonApiType;
+        this.jsonApiId = jsonApiId;
         this.queriedRelationName = queriedRelationName;
         this.include = [];
         this.filters = [];
@@ -92,9 +95,17 @@ export class Query
 
     public toString(): string
     {
-        let relationToFind: string = this.queriedRelationName
-            ? '/' + this.queriedRelationName
-            : '';
+        let relationToFind = '';
+
+        if (!this.jsonApiId) {
+            relationToFind = this.queriedRelationName
+                ? '/' + this.queriedRelationName
+                : '';
+        } else {
+            relationToFind = this.queriedRelationName
+                ? '/' + this.jsonApiId + '/relationships/' + this.queriedRelationName
+                : '';
+        }
 
         let idToFind: string = this.idToFind
             ? '/' + this.idToFind

--- a/src/relation/ToManyRelation.ts
+++ b/src/relation/ToManyRelation.ts
@@ -8,37 +8,37 @@ import {SortDirection} from "../SortDirection";
 export class ToManyRelation extends Relation implements QueryMethods
 {
     get(page?: number): Promise<PluralResponse> {
-        return <Promise<PluralResponse>> new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType())
+        return <Promise<PluralResponse>> new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .get(page);
     }
 
     first(): Promise<SingularResponse> {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType())
+        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .first();
     }
 
     find(id: string | number): Promise<SingularResponse> {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType())
+        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .find(id);
     }
 
     where(attribute: string, value: string): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType())
+        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .where(attribute, value);
     }
 
     with(value: any): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType())
+        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .with(value);
     }
 
     public orderBy(attribute: string, direction?: SortDirection|string): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType())
+        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .orderBy(attribute, direction);
     }
 
     option(queryParameter: string, value: string): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType())
+        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .option(queryParameter, value);
     }
 }

--- a/src/relation/ToOneRelation.ts
+++ b/src/relation/ToOneRelation.ts
@@ -8,37 +8,37 @@ import {SortDirection} from "../SortDirection";
 export class ToOneRelation extends Relation implements QueryMethods
 {
     get(page?: number): Promise<SingularResponse> {
-        return <Promise<SingularResponse>> new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), true)
+        return <Promise<SingularResponse>> new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .get(page);
     }
 
     first(): Promise<SingularResponse> {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), true)
+        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .first();
     }
 
     find(id: string | number): Promise<SingularResponse> {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), true)
+        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .find(id);
     }
 
     where(attribute: string, value: string): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), true)
+        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .where(attribute, value);
     }
 
     with(value: any): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), true)
+        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .with(value);
     }
 
     orderBy(attribute: string, direction?: SortDirection|string): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), true)
+        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .orderBy(attribute, direction);
     }
 
     option(queryParameter: string, value: string): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), true)
+        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .option(queryParameter, value);
     }
 }

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -81,4 +81,17 @@ describe('Query', () => {
 
         assert.equal(query.toString(), model.getJsonApiType()+'?sort=name%2C-age');
     });
+
+    it('when a JSON-API id is provided, it should parse the relationships to "relationships/\<relation\>"', () => {
+        query = new Query('hero', 'capes', 'batman');
+        query.setPaginationSpec(
+            new OffsetBasedPaginationSpec(
+                Hero.getPaginationOffsetParamName(),
+                Hero.getPaginationLimitParamName(),
+                Hero.getPageSize()
+            )
+        )
+
+        assert.equal(query.toString(), 'hero/batman/relationships/capes');
+    });
 });

--- a/tests/Relation.test.ts
+++ b/tests/Relation.test.ts
@@ -37,4 +37,32 @@ describe('Relation', () => {
             done();
         });
     });
+
+    it('yields a query with "<base class\>/<\<base id\>/relationships/\<relation class\>" at the start of the URL when an id is provided when using ToManyRelation', (done) => {
+        model.setApiId('superman');
+
+        model
+            .friends()
+            .get();
+
+        moxios.wait(() => {
+            let request = moxios.requests.mostRecent();
+            assert.equal(request.url.split('?')[0], model.getJsonApiBaseUrl()+'heros/superman/relationships/friends');
+            done();
+        });
+    });
+
+    it('yields a query with "<base class\>/<\<base id\>/relationships/\<relation class\>" at the start of the URL when an id is provided when using ToOneRelation', (done) => {
+        model.setApiId('superman');
+
+        model
+            .rival()
+            .get();
+
+        moxios.wait(() => {
+            let request = moxios.requests.mostRecent();
+            assert.equal(request.url.split('?')[0], model.getJsonApiBaseUrl()+'heros/superman/relationships/rival');
+            done();
+        });
+    });
 });


### PR DESCRIPTION
This PR will allow the usage of fetching relationships via their own URLs (https://jsonapi.org/format/#fetching-relationships). 

Only when the ID of the "base model" is known, this behavior is applied. Otherwise the current implementation is used.