### PR TITLE
Fixes #59: Wrong URL used for fetching relationship-resource(s)

### DIFF
--- a/src/Query.ts
+++ b/src/Query.ts
@@ -103,7 +103,7 @@ export class Query
                 : '';
         } else {
             relationToFind = this.queriedRelationName
-                ? '/' + this.jsonApiId + '/relationships/' + this.queriedRelationName
+                ? '/' + this.jsonApiId + '/' + this.queriedRelationName
                 : '';
         }
 

--- a/tests/Query.test.ts
+++ b/tests/Query.test.ts
@@ -82,7 +82,7 @@ describe('Query', () => {
         assert.equal(query.toString(), model.getJsonApiType()+'?sort=name%2C-age');
     });
 
-    it('when a JSON-API id is provided, it should parse the relationships to "relationships/\<relation\>"', () => {
+    it('when a JSON-API id is provided, it should parse the relationships to "\<relation\>"', () => {
         query = new Query('hero', 'capes', 'batman');
         query.setPaginationSpec(
             new OffsetBasedPaginationSpec(
@@ -92,6 +92,6 @@ describe('Query', () => {
             )
         )
 
-        assert.equal(query.toString(), 'hero/batman/relationships/capes');
+        assert.equal(query.toString(), 'hero/batman/capes');
     });
 });

--- a/tests/Relation.test.ts
+++ b/tests/Relation.test.ts
@@ -38,7 +38,7 @@ describe('Relation', () => {
         });
     });
 
-    it('yields a query with "<base class\>/<\<base id\>/relationships/\<relation class\>" at the start of the URL when an id is provided when using ToManyRelation', (done) => {
+    it('yields a query with "<base class\>/<\<base id\>/\<relation class\>" at the start of the URL when an id is provided when using ToManyRelation', (done) => {
         model.setApiId('superman');
 
         model
@@ -47,12 +47,12 @@ describe('Relation', () => {
 
         moxios.wait(() => {
             let request = moxios.requests.mostRecent();
-            assert.equal(request.url.split('?')[0], model.getJsonApiBaseUrl()+'heros/superman/relationships/friends');
+            assert.equal(request.url.split('?')[0], model.getJsonApiBaseUrl()+'heros/superman/friends');
             done();
         });
     });
 
-    it('yields a query with "<base class\>/<\<base id\>/relationships/\<relation class\>" at the start of the URL when an id is provided when using ToOneRelation', (done) => {
+    it('yields a query with "<base class\>/<\<base id\>/\<relation class\>" at the start of the URL when an id is provided when using ToOneRelation', (done) => {
         model.setApiId('superman');
 
         model
@@ -61,7 +61,7 @@ describe('Relation', () => {
 
         moxios.wait(() => {
             let request = moxios.requests.mostRecent();
-            assert.equal(request.url.split('?')[0], model.getJsonApiBaseUrl()+'heros/superman/relationships/rival');
+            assert.equal(request.url.split('?')[0], model.getJsonApiBaseUrl()+'heros/superman/rival');
             done();
         });
     });


### PR DESCRIPTION
When fetching the relationship of an entity (sa a resource), don't add the /relationship to the URL (since that would only fetch the relationship). This PR fixes https://github.com/DavidDuwaer/Coloquent/issues/59