### PR TITLE
Fix for plural relations not working because of casing

### DIFF
--- a/src/response/RetrievalResponse.ts
+++ b/src/response/RetrievalResponse.ts
@@ -89,7 +89,7 @@ export abstract class RetrievalResponse extends Response
                 continue;
             }
 
-            const includeSubtree = includeTree ? includeTree[modelRelationName] : {};
+            const includeSubtree = includeTree ? includeTree[resourceRelationName] : {};
             let relation: Relation = model[modelRelationName]();
             if (relation instanceof ToManyRelation) {
                 let relatedStubs: ResourceStub[] = (doc.relationships !== undefined && doc.relationships[resourceRelationName] !== undefined)

--- a/tests/model3/dummy/AntiHero.ts
+++ b/tests/model3/dummy/AntiHero.ts
@@ -1,0 +1,17 @@
+import {BaseModel} from './BaseModel';
+import {ToManyRelation} from "../../../dist";
+import {Hero} from "./Hero";
+
+export class AntiHero extends BaseModel
+{
+    protected jsonApiType = 'anti-heroes';
+
+    public heroes(): ToManyRelation
+    {
+        return this.hasMany(Hero, 'heros');
+    }
+
+    public getName(): string {
+        return this.getAttribute('name');
+    }
+}

--- a/tests/model3/dummy/BaseModel.ts
+++ b/tests/model3/dummy/BaseModel.ts
@@ -1,0 +1,14 @@
+import {AxiosInstance} from "axios";
+import * as moxios from 'moxios';
+import {Model} from "../../../dist";
+
+export abstract class BaseModel extends Model {
+    constructor() {
+        super();
+        moxios.install((<AxiosInstance> BaseModel.getHttpClient().getImplementingClient()));
+    }
+
+    getJsonApiBaseUrl(): string {
+        return 'http://coloquent.app/api/';
+    }
+}

--- a/tests/model3/dummy/Hero.ts
+++ b/tests/model3/dummy/Hero.ts
@@ -1,0 +1,18 @@
+import {BaseModel} from './BaseModel';
+import {ToManyRelation} from "../../../dist";
+import {AntiHero} from "./AntiHero";
+
+export class Hero extends BaseModel
+{
+    protected jsonApiType = 'heros';
+
+    public antiHeroes(): ToManyRelation
+    {
+        return this.hasMany(AntiHero, 'anti-heroes');
+    }
+
+    public getAntiHeroes(): Array<AntiHero>
+    {
+        return this.getRelation('antiHeroes');
+    }
+}


### PR DESCRIPTION
Plural relations were not working because of camel case and kebab case.
It tries finding 'example-relation' instead exampleRelation in the model.