### PR TITLE
Set the default content-type headers to be application/vnd.api+json

### DIFF
--- a/src/httpclient/axios/AxiosHttpClient.ts
+++ b/src/httpclient/axios/AxiosHttpClient.ts
@@ -12,6 +12,8 @@ export class AxiosHttpClient implements HttpClient
     constructor(axiosInstance?: AxiosInstance) {
         if (axiosInstance === null || axiosInstance === undefined) {
             axiosInstance = axios.create();
+            axiosInstance.defaults.headers['Accept'] = 'application/vnd.api+json';
+            axiosInstance.defaults.headers['Content-type'] = 'application/vnd.api+json';
         }
         this.axiosInstance = axiosInstance;
     }

--- a/tests/model1/Model.test.ts
+++ b/tests/model1/Model.test.ts
@@ -266,4 +266,20 @@ describe('Model1', () => {
             done();
         });
     });
+
+    it('should have the application/vnd.api+json content-type in the header', (done) => {
+        const hero = new Hero();
+        hero.setName('MeatMan');
+
+        hero.save();
+
+        moxios.wait(() => {
+            const request = moxios.requests.mostRecent();
+            const headers = request.headers;
+
+            expect(headers['Content-Type']).to.equal('application/vnd.api+json');
+
+            done();
+        })
+    })
 });


### PR DESCRIPTION
I have set the default `Content-Type` for axios requests to be application/vnd.api+json.

This is according to the [JSON API spec](https://jsonapi.org/format/#content-negotiation)