### PR TITLE
Builder clone method

### DIFF
--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -158,6 +158,32 @@ export class Builder implements QueryMethods
         return this;
     }
 
+    public clone(): Builder 
+    {
+        let clone = Object.create(this);
+        let query = new Query(this.query.getJsonApiType(), this.query.getQueriedRelationName(), this.query.getJsonApiId());
+
+        this.query.getFilters().forEach(filter => query.addFilter(filter));
+        this.query.getOptions().forEach(option => query.addOption(option));
+        this.query.getSort().forEach(sort => query.addSort(sort));
+        this.query.getInclude().forEach(include => query.addInclude(include));
+        query.setPaginationSpec(Object.create(this.query.getPaginationSpec()));
+
+        clone.setQuery(query);
+
+        return clone;
+    }
+
+    public getQuery(): Query
+    {
+        return this.query;
+    }
+
+    public setQuery(query: Query): void
+    {
+        this.query = query;
+    }
+
     private initPaginationSpec(): void
     {
         let paginationStrategy = this.modelType.getPaginationStrategy();

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -49,13 +49,14 @@ export class Builder implements QueryMethods
 
     public get(page: number = 0): Promise<Response>
     {
-        this.query.getPaginationSpec().setPage(page);
+        const clone = this.clone();
+        clone.getQuery().getPaginationSpec().setPage(page);
         if (this.forceSingular) {
             return <Promise<SingularResponse>> this.getHttpClient()
-                .get(this.query.toString())
+                .get(clone.getQuery().toString())
                 .then(
                     (response: HttpClientResponse) => {
-                        return new SingularResponse(this.query, response, this.modelType, response.getData());
+                        return new SingularResponse(clone.getQuery(), response, this.modelType, response.getData());
                     },
                     function (response: AxiosError) {
                         throw new Error((<Error> response).message);
@@ -63,10 +64,10 @@ export class Builder implements QueryMethods
                 );
         } else {
             return <Promise<PluralResponse>> this.getHttpClient()
-                .get(this.query.toString())
+                .get(clone.getQuery().toString())
                 .then(
                     (response: HttpClientResponse) => {
-                        return new PluralResponse(this.query, response, this.modelType, response.getData(), page);
+                        return new PluralResponse(clone.getQuery(), response, this.modelType, response.getData(), page);
                     },
                     function (response: AxiosError) {
                         throw new Error((<Error> response).message);
@@ -77,7 +78,8 @@ export class Builder implements QueryMethods
 
     public first(): Promise<SingularResponse>
     {
-        this.query.getPaginationSpec().setPageLimit(1);
+        const clone = this.clone();
+        clone.getQuery().getPaginationSpec().setPageLimit(1);
         return <Promise<SingularResponse>> this.getHttpClient()
             .get(this.query.toString())
             .then(
@@ -92,12 +94,13 @@ export class Builder implements QueryMethods
 
     public find(id: string | number): Promise<SingularResponse>
     {
-        this.query.setIdToFind(id);
-        return <Promise<SingularResponse>> this.getHttpClient()
-            .get(this.query.toString())
+        const clone = this.clone();
+        clone.query.setIdToFind(id);
+        return <Promise<SingularResponse>> clone.getHttpClient()
+            .get(clone.getQuery().toString())
             .then(
                 (response: HttpClientResponse) => {
-                    return new SingularResponse(this.query, response, this.modelType, response.getData());
+                    return new SingularResponse(clone.getQuery(), response, this.modelType, response.getData());
                 },
                 function (response: AxiosError) {
                     throw new Error((<Error> response).message);
@@ -107,22 +110,26 @@ export class Builder implements QueryMethods
 
     public where(attribute: string, value: string): Builder
     {
-        this.query.addFilter(new FilterSpec(attribute, value));
-        return this;
+        const clone = this.clone();
+        clone.getQuery().addFilter(new FilterSpec(attribute, value));
+        return clone;
     }
 
     public with(value: any): Builder
     {
+        const clone = this.clone();
+
         if (typeof value === 'string') {
-            this.query.addInclude(value);
+            clone.getQuery().addInclude(value);
         } else if (Array.isArray(value)) {
             for (let v of value) {
-                this.query.addInclude(v);
+                clone.getQuery().addInclude(v);
             }
         } else {
             throw new Error("The argument for 'with' must be a string or an array of strings.");
         }
-        return this;
+
+        return clone;
     }
 
     public orderBy(attribute: string, direction?: SortDirection|string): Builder
@@ -141,24 +148,31 @@ export class Builder implements QueryMethods
                 );
             }
         }
-        this.query.addSort(
+
+        const clone = this.clone();
+
+        clone.getQuery().addSort(
             new SortSpec(
                 attribute,
                 direction === SortDirection.ASC
             )
         );
-        return this;
+        
+        return clone;
     }
 
     public option(queryParameter: string, value: string): Builder
     {
-        this.query.addOption(
+        const clone = this.clone();
+
+        clone.getQuery().addOption(
             new Option(queryParameter, value)
         );
-        return this;
+
+        return clone;
     }
 
-    public clone(): Builder 
+    private clone(): Builder 
     {
         let clone = Object.create(this);
         let query = new Query(this.query.getJsonApiType(), this.query.getQueriedRelationName(), this.query.getJsonApiId());

--- a/src/Query.ts
+++ b/src/Query.ts
@@ -130,6 +130,21 @@ export class Query
         return this.jsonApiType + relationToFind + idToFind + paramString;
     }
 
+    public getJsonApiType()
+    {
+        return this.jsonApiType;
+    }
+
+    public getJsonApiId()
+    {
+        return this.jsonApiId;
+    }
+
+    public getQueriedRelationName()
+    {
+        return this.queriedRelationName;
+    }
+
     public setIdToFind(idToFind: string | number): void
     {
         this.idToFind = idToFind;
@@ -150,9 +165,18 @@ export class Query
         this.include.push(includeSpec);
     }
 
+    getInclude(): string[] {
+        return this.include;
+    }
+
     public addFilter(filter: FilterSpec): void
     {
         this.filters.push(filter);
+    }
+
+    public getFilters(): FilterSpec[]
+    {
+        return this.filters;
     }
 
     public addSort(sort: SortSpec): void
@@ -160,9 +184,19 @@ export class Query
         this.sort.push(sort);
     }
 
+    public getSort(): SortSpec[]
+    {
+        return this.sort;
+    }
+
     public addOption(option: Option): void
     {
         this.options.push(option);
+    }
+
+    public getOptions(): Option[]
+    {
+        return this.options;
     }
 
     /**

--- a/src/paginationspec/OffsetBasedPaginationSpec.ts
+++ b/src/paginationspec/OffsetBasedPaginationSpec.ts
@@ -26,6 +26,8 @@ export class OffsetBasedPaginationSpec extends PaginationSpec
 
     public getPaginationParameters(): QueryParam[]
     {
+        this.queryParams = [];
+
         if (this.pageOffset !== undefined) {
             this.queryParams.push(new QueryParam(`${this.pageOffsetParamName}`, this.pageOffset));
             this.queryParams.push(new QueryParam(`${this.pageLimitParamName}`, this.pageLimit));

--- a/src/paginationspec/PageBasedPaginationSpec.ts
+++ b/src/paginationspec/PageBasedPaginationSpec.ts
@@ -26,6 +26,8 @@ export class PageBasedPaginationSpec extends PaginationSpec
 
     public getPaginationParameters(): QueryParam[]
     {
+        this.queryParams = [];
+
         if (this.pageNumber !== undefined) {
             this.queryParams.push(new QueryParam(`${this.pageNumberParamName}`, this.pageNumber));
             this.queryParams.push(new QueryParam(`${this.pageSizeParamName}`, this.pageLimit));

--- a/tests/Builder.test.ts
+++ b/tests/Builder.test.ts
@@ -70,7 +70,7 @@ describe('Builder', () => {
         moxios.requests.reset();
 
         builder.where('foo', 'bar');
-        let builderClone = builder.clone();
+        let builderClone = builder;
 
         builder
             .get();
@@ -90,7 +90,7 @@ describe('Builder', () => {
     it('where method applied after clone should generate different url result', (done) => {
         moxios.requests.reset();
 
-        let builderClone = builder.clone();
+        let builderClone = builder;
 
         builder
             .where('name', 'Bob')
@@ -163,7 +163,7 @@ describe('Builder', () => {
         builder
             .with('weapons');
         
-        let builderClone = builder.clone();
+        let builderClone = builder;
         
         builder
             .get();
@@ -184,7 +184,7 @@ describe('Builder', () => {
     it('with method applied after clone should generate different url result', (done) => {
         moxios.requests.reset();
         
-        let builderClone = builder.clone();
+        let builderClone = builder;
         
         builder
             .with('weapons')
@@ -298,7 +298,7 @@ describe('Builder', () => {
         builder
             .orderBy('name');
 
-        let builderClone = builder.clone();
+        let builderClone = builder;
 
         builder
             .get();
@@ -319,7 +319,7 @@ describe('Builder', () => {
     it('orderBy method applied after clone should generate different url result', (done) => {
         moxios.requests.reset();
 
-        let builderClone = builder.clone();
+        let builderClone = builder;
 
         builder
             .orderBy('name')
@@ -364,7 +364,7 @@ describe('Builder', () => {
         builder
             .option('foo', 'bar');
 
-        let builderClone = builder.clone();
+        let builderClone = builder;
 
         builder
             .get();
@@ -385,7 +385,7 @@ describe('Builder', () => {
     it('option method applied after clone should generate different url result', (done) => {
         moxios.requests.reset();
 
-        let builderClone = builder.clone();
+        let builderClone = builder;
 
         builder
             .option('foo', 'bar')

--- a/tests/Builder.test.ts
+++ b/tests/Builder.test.ts
@@ -66,6 +66,56 @@ describe('Builder', () => {
         });
     });
 
+    it('where method applied before clone should generate same url result', (done) => {
+        moxios.requests.reset();
+
+        builder.where('foo', 'bar');
+        let builderClone = builder.clone();
+
+        builder
+            .get();
+
+        builderClone
+            .get();
+
+        moxios.wait(() => {
+            let request = moxios.requests.at(0);
+            let requestClone = moxios.requests.at(1);
+
+            assert.equal(request.url, requestClone.url);
+            done();
+        });
+    });
+
+    it('where method applied after clone should generate different url result', (done) => {
+        moxios.requests.reset();
+
+        let builderClone = builder.clone();
+
+        builder
+            .where('name', 'Bob')
+            .get();
+
+        builderClone
+            .where('name', 'Josh')
+            .get();
+
+        moxios.wait(() => {
+            let request = moxios.requests.at(0);
+            let requestClone = moxios.requests.at(1);
+
+            assert.notEqual(request.url, requestClone.url);
+            
+            assert.notInclude(request.url, 'filter%5Bname%5D=Josh');
+            assert.notInclude(requestClone.url, 'filter%5Bname%5D=Bob');
+
+            assert.include(request.url, 'filter%5Bname%5D=Bob');
+            assert.include(requestClone.url, 'filter%5Bname%5D=Josh');
+
+            done();
+        });
+    });
+
     it('with method should add include parameters to query string', (done) => {
         builder
             .with('weapons')
@@ -105,6 +155,57 @@ describe('Builder', () => {
                 .get();
 
         }).to.throw('The argument for \'with\' must be a string or an array of strings.');
+    });
+
+    it('with method applied before clone should generate same url result', (done) => {
+        moxios.requests.reset();
+        
+        builder
+            .with('weapons');
+        
+        let builderClone = builder.clone();
+        
+        builder
+            .get();
+
+        builderClone
+            .get();
+
+        moxios.wait(() => {
+            let request = moxios.requests.at(0);
+            let cloneRequest = moxios.requests.at(1);
+
+            assert.equal(request.url, cloneRequest.url);
+
+            done();
+        });
+    });
+
+    it('with method applied after clone should generate different url result', (done) => {
+        moxios.requests.reset();
+        
+        let builderClone = builder.clone();
+        
+        builder
+            .with('weapons')
+            .get();
+
+        builderClone
+            .with('costume')
+            .get();
+
+        moxios.wait(() => {
+            let request = moxios.requests.at(0);
+            let requestClone = moxios.requests.at(1);
+
+            assert.notInclude(request.url, 'include=costume');
+            assert.notInclude(requestClone.url, 'include=weapons');
+
+            assert.include(request.url, 'include=weapons');
+            assert.include(requestClone.url, 'include=costume');
+
+            done();
+        });
     });
 
     it('orderBy method should add order parameters to query string', (done) => {
@@ -191,6 +292,57 @@ describe('Builder', () => {
         }).to.throw();
     });
 
+    it('orderBy method applied before clone should generate same url result', (done) => {
+        moxios.requests.reset();
+        
+        builder
+            .orderBy('name');
+
+        let builderClone = builder.clone();
+
+        builder
+            .get();
+
+        builderClone
+            .get();
+
+        moxios.wait(() => {
+            let request = moxios.requests.at(0);
+            let requestClone = moxios.requests.at(1);
+
+            assert.equal(request.url, requestClone.url);
+
+            done();
+        });
+    });
+
+    it('orderBy method applied after clone should generate different url result', (done) => {
+        moxios.requests.reset();
+
+        let builderClone = builder.clone();
+
+        builder
+            .orderBy('name')
+            .get();
+
+        builderClone
+            .orderBy('foo')
+            .get();
+
+        moxios.wait(() => {
+            let request = moxios.requests.at(0);
+            let requestClone = moxios.requests.at(1);
+
+            assert.notInclude(request.url, 'sort=foo');
+            assert.notInclude(requestClone.url, 'sort=name');
+
+            assert.include(request.url, 'sort=name');
+            assert.include(requestClone.url, 'sort=foo');
+
+            done();
+        });
+    });
+
     it('option method should allow adding parameters to query string', (done) => {
         builder
             .option('foo', 'bar')
@@ -201,6 +353,57 @@ describe('Builder', () => {
 
             assert.equal(request.config.method, 'get');
             assert.include(request.url, 'foo=bar');
+
+            done();
+        });
+    });
+
+    it('option method applied before clone should generate same url result', (done) => {
+        moxios.requests.reset();
+        
+        builder
+            .option('foo', 'bar');
+
+        let builderClone = builder.clone();
+
+        builder
+            .get();
+
+        builderClone
+            .get();
+
+        moxios.wait(() => {
+            let request = moxios.requests.at(0);
+            let requestClone = moxios.requests.at(1);
+
+            assert.equal(request.url, requestClone.url);
+
+            done();
+        });
+    });
+
+    it('option method applied after clone should generate different url result', (done) => {
+        moxios.requests.reset();
+
+        let builderClone = builder.clone();
+
+        builder
+            .option('foo', 'bar')
+            .get();
+
+        builderClone
+            .option('baz', 'qux')
+            .get();
+
+        moxios.wait(() => {
+            let request = moxios.requests.at(0);
+            let requestClone = moxios.requests.at(1);
+
+            assert.notInclude(request.url, 'baz=qux');
+            assert.notInclude(requestClone.url, 'foo=bar');
+
+            assert.include(request.url, 'foo=bar');
+            assert.include(requestClone.url, 'baz=qux');
 
             done();
         });


### PR DESCRIPTION
A clone method on Builder is useful when you need to create an instance copy with all properties defined so far, but with a different reference so the changes made to the clone do not affect the original instance and vice versa.