### PR TITLE
Add possibility to call query method statically

### DIFF
--- a/src/Model.ts
+++ b/src/Model.ts
@@ -97,7 +97,16 @@ export abstract class Model
      */
     public query(): Builder
     {
-        return new Builder(this.constructor);
+        return this.constructor.query();
+    }
+
+    /**
+     * Get a {@link Builder} instance from a static {@link Model}
+     * so you can start querying
+     */
+    public static query(): Builder
+    {
+        return new Builder(this);
     }
 
     public static get(page?: number): Promise<PluralResponse>


### PR DESCRIPTION
It would be great be able to get the builder instance directly from the static model, without having to start a query.

This is useful when for example, your have a method that receives a Builder, and all you have is a static model. Currenctly for achiving this, i have to do a ```(new Model).query()``` or ```Model.option('_', '_')```.