### PR TITLE
Use resourceIndex instead of modelIndex in makeIncludedArray function in RetrievalResponse.ts

### DIFF
--- a/src/response/RetrievalResponse.ts
+++ b/src/response/RetrievalResponse.ts
@@ -19,7 +19,7 @@ export abstract class RetrievalResponse extends Response
 
     protected modelIndex: Map<Map<Model>>;
 
-    protected included: Model[];
+    protected included: Resource[];
 
     constructor(
         query: Query,
@@ -46,7 +46,7 @@ export abstract class RetrievalResponse extends Response
 
     public abstract getData(): any;
 
-    public getIncluded(): Model[]
+    public getIncluded(): Resource[]
     {
         return this.included;
     }
@@ -134,7 +134,7 @@ export abstract class RetrievalResponse extends Response
     {
         this.included = [];
         for (let doc of includedDocs) {
-            const models = this.modelIndex.get(doc.type);
+            const models = this.resourceIndex.get(doc.type);
             if (models !== undefined) {
                 this.included.push(models.get(doc.id));
             }


### PR DESCRIPTION
I'm not sure if this is a bug, but in my case everything works as expected after I changed it to this. 
Maybe it was a little mix-up on your side. Or my JSON:API is not according to specs.
Just look into it - tests work.