### PR TITLE
Typescript generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This will retrieve only a single model from the server. To retrieve a single mod
 Artist.find(324);
 ```
 To query a relation of an object you've instantiated:
-```typescript
+```javascript
 artist.albums()
     .orderBy('name', SortDirection.DESC)
     .get()
@@ -102,6 +102,18 @@ var student = teacher.getStudents()[0];
 ```
 
 The variables `teacher`, `schoolAddress` and `student` now all contain full-fledged model objects.
+
+#### Note for TypeScript users
+
+You should specify model class as generic type of any static method invocation.
+
+```typescript
+Artist.get<Artist>().then((response) => {
+    const data = response.getData();
+    // data is now properly inferred as Artist[] instead of Model[]
+    // You don't have to cast anything thanks to provided generic type.
+})
+```
 
 ### Creating / updating
 
@@ -165,7 +177,7 @@ class Artist extends AppModel
         'age'
     ];
 
-    albums(): ToManyRelation
+    albums(): ToManyRelation<Album, this>
     {
         return this.hasMany(Album);
     }
@@ -200,12 +212,12 @@ class Album extends AppModel
 {
     jsonApiType = 'albums';
 
-    artist(): ToOneRelation
+    artist(): ToOneRelation<Artist, this>
     {
         return this.hasOne(Artist);
     }
 
-    songs(): ToManyRelation
+    songs(): ToManyRelation<Song, this>
     {
         return this.hasMany(Song);
     }
@@ -225,7 +237,7 @@ class Song extends AppModel
 {
     jsonApiType = 'songs';
 
-    album(): ToOneRelation
+    album(): ToOneRelation<Album, this>
     {
         return this.hasOne(Album);
     }

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -16,9 +16,9 @@ import {SortDirection} from "./SortDirection";
 
 export class Builder<M extends Model = Model> implements QueryMethods<M>
 {
-    protected modelType: any;
+    protected readonly modelType: any;
 
-    private httpClient: HttpClient;
+    private readonly httpClient: HttpClient;
 
     private query: Query;
 

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -10,7 +10,6 @@ import {OffsetBasedPaginationSpec} from "./paginationspec/OffsetBasedPaginationS
 import {PageBasedPaginationSpec} from "./paginationspec/PageBasedPaginationSpec";
 import {Query} from "./Query";
 import {QueryMethods} from "./QueryMethods";
-import {Response} from "./response/Response";
 import {HttpClientResponse} from "./httpclient/HttpClientResponse";
 import {HttpClient} from "./httpclient/HttpClient";
 import {SortDirection} from "./SortDirection";
@@ -47,7 +46,7 @@ export class Builder implements QueryMethods
         this.forceSingular = forceSingular;
     }
 
-    public get(page: number = 0): Promise<Response>
+    public get(page: number = 0): Promise<SingularResponse | PluralResponse>
     {
         const clone = this.clone();
         clone.getQuery().getPaginationSpec().setPage(page);

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -95,7 +95,7 @@ export abstract class Model
      * so you can query without having a static reference to your specific {@link Model}
      * class.
      */
-    public query(): Builder
+    public query(): Builder<this>
     {
         return this.constructor.query();
     }
@@ -104,56 +104,56 @@ export abstract class Model
      * Get a {@link Builder} instance from a static {@link Model}
      * so you can start querying
      */
-    public static query(): Builder
+    public static query<M extends Model>(): Builder<M>
     {
         return new Builder(this);
     }
 
-    public static get(page?: number): Promise<PluralResponse>
+    public static get<M extends Model>(page?: number): Promise<PluralResponse<M>>
     {
-        return <Promise<PluralResponse>> new Builder(this)
+        return <Promise<PluralResponse<M>>> new Builder(this)
             .get(page);
     }
 
-    public static first(): Promise<SingularResponse>
+    public static first<M extends Model>(): Promise<SingularResponse<M>>
     {
-        return new Builder(this)
+        return new Builder<M>(this)
             .first();
     }
 
-    public static find(id: string | number): Promise<SingularResponse>
+    public static find<M extends Model>(id: string | number): Promise<SingularResponse<M>>
     {
-        return new Builder(this)
+        return new Builder<M>(this)
             .find(id);
     }
 
-    public static with(attribute: any): Builder
+    public static with<M extends Model>(attribute: any): Builder<M>
     {
-        return new Builder(this)
+        return new Builder<M>(this)
             .with(attribute);
     }
 
-    public static limit(limit: number): Builder
+    public static limit<M extends Model>(limit: number): Builder<M>
     {
-        return new Builder(this)
+        return new Builder<M>(this)
             .limit(limit);
     }
 
-    public static where(attribute: string, value: string): Builder
+    public static where<M extends Model>(attribute: string, value: string): Builder<M>
     {
-        return new Builder(this)
+        return new Builder<M>(this)
             .where(attribute, value);
     }
 
-    public static orderBy(attribute: string, direction?: string): Builder
+    public static orderBy<M extends Model>(attribute: string, direction?: string): Builder<M>
     {
-        return new Builder(this)
+        return new Builder<M>(this)
             .orderBy(attribute, direction);
     }
 
-    public static option(queryParameter: string, value: string): Builder
+    public static option<M extends Model>(queryParameter: string, value: string): Builder<M>
     {
-        return new Builder(this)
+        return new Builder<M>(this)
             .option(queryParameter, value);
     }
 
@@ -207,7 +207,7 @@ export abstract class Model
         };
     }
 
-    public save(): Promise<SaveResponse>
+    public save(): Promise<SaveResponse<this>>
     {
         if (!this.hasId) {
             return this.create();
@@ -231,7 +231,7 @@ export abstract class Model
             );
     }
 
-    public create(): Promise<SaveResponse>
+    public create(): Promise<SaveResponse<this>>
     {
         let payload = this.serialize();
         return Model.httpClient
@@ -280,8 +280,8 @@ export abstract class Model
             return builder
                 .find(<string>this.getApiId())
                 .then(
-                    (response: SingularResponse) => {
-                        let model = <this> response.getData();
+                    (response: SingularResponse<this>) => {
+                        let model = response.getData();
                         return model;
                     },
                     (response: AxiosError) => {
@@ -465,9 +465,9 @@ export abstract class Model
         this.id = id;
     }
 
-    protected hasMany(relatedType: typeof Model): ToManyRelation;
-    protected hasMany(relatedType: typeof Model, relationName: string): ToManyRelation;
-    protected hasMany(relatedType: typeof Model, relationName?: string): ToManyRelation
+    protected hasMany<R extends Model>(relatedType: typeof Model): ToManyRelation<R, this>;
+    protected hasMany<R extends Model>(relatedType: typeof Model, relationName: string): ToManyRelation<R, this>;
+    protected hasMany<R extends Model>(relatedType: typeof Model, relationName?: string): ToManyRelation<R, this>
     {
         if (typeof relationName === 'undefined') {
             relationName = Reflection.getNameOfNthMethodOffStackTrace(new Error(), 2);
@@ -475,9 +475,9 @@ export abstract class Model
         return new ToManyRelation(relatedType, this, relationName);
     }
 
-    protected hasOne(relatedType: typeof Model): ToOneRelation;
-    protected hasOne(relatedType: typeof Model, relationName: string): ToOneRelation;
-    protected hasOne(relatedType: typeof Model, relationName?: string): ToOneRelation
+    protected hasOne<R extends Model>(relatedType: typeof Model): ToOneRelation<R, this>;
+    protected hasOne<R extends Model>(relatedType: typeof Model, relationName: string): ToOneRelation<R, this>;
+    protected hasOne<R extends Model>(relatedType: typeof Model, relationName?: string): ToOneRelation<R, this>
     {
         if (typeof relationName === 'undefined') {
             relationName = Reflection.getNameOfNthMethodOffStackTrace(new Error(), 2);

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -95,7 +95,7 @@ export abstract class Model
      * so you can query without having a static reference to your specific {@link Model}
      * class.
      */
-    public query(): Builder<this>
+    public query(): Builder<this, PluralResponse<this>>
     {
         return this.constructor.query();
     }
@@ -104,7 +104,7 @@ export abstract class Model
      * Get a {@link Builder} instance from a static {@link Model}
      * so you can start querying
      */
-    public static query<M extends Model>(): Builder<M>
+    public static query<M extends Model>(): Builder<M, PluralResponse<M>>
     {
         return new Builder(this);
     }
@@ -127,31 +127,31 @@ export abstract class Model
             .find(id);
     }
 
-    public static with<M extends Model>(attribute: any): Builder<M>
+    public static with<M extends Model>(attribute: any): Builder<M, PluralResponse<M>>
     {
         return new Builder<M>(this)
             .with(attribute);
     }
 
-    public static limit<M extends Model>(limit: number): Builder<M>
+    public static limit<M extends Model>(limit: number): Builder<M, PluralResponse<M>>
     {
         return new Builder<M>(this)
             .limit(limit);
     }
 
-    public static where<M extends Model>(attribute: string, value: string): Builder<M>
+    public static where<M extends Model>(attribute: string, value: string): Builder<M, PluralResponse<M>>
     {
         return new Builder<M>(this)
             .where(attribute, value);
     }
 
-    public static orderBy<M extends Model>(attribute: string, direction?: string): Builder<M>
+    public static orderBy<M extends Model>(attribute: string, direction?: string): Builder<M, PluralResponse<M>>
     {
         return new Builder<M>(this)
             .orderBy(attribute, direction);
     }
 
-    public static option<M extends Model>(queryParameter: string, value: string): Builder<M>
+    public static option<M extends Model>(queryParameter: string, value: string): Builder<M, PluralResponse<M>>
     {
         return new Builder<M>(this)
             .option(queryParameter, value);

--- a/src/QueryMethods.ts
+++ b/src/QueryMethods.ts
@@ -1,6 +1,6 @@
 import {Builder} from "./Builder";
 import {SingularResponse} from "./response/SingularResponse";
-import {Response} from "./response/Response";
+import {PluralResponse} from "./response/PluralResponse";
 import {SortDirection} from "./SortDirection";
 
 export interface QueryMethods
@@ -9,7 +9,7 @@ export interface QueryMethods
      * Fetches a single page
      * @param page
      */
-    get(page: number): Promise<Response>;
+    get(page: number): Promise<SingularResponse | PluralResponse>;
 
     /**
      * Fetches the first result available in the backend

--- a/src/QueryMethods.ts
+++ b/src/QueryMethods.ts
@@ -3,14 +3,15 @@ import {SingularResponse} from "./response/SingularResponse";
 import {PluralResponse} from "./response/PluralResponse";
 import {SortDirection} from "./SortDirection";
 import {Model} from "./Model";
+import {RetrievalResponse} from "./response/RetrievalResponse";
 
-export interface QueryMethods<M extends Model = Model>
+export interface QueryMethods<M extends Model = Model, GET_RESPONSE extends RetrievalResponse<M> = PluralResponse<M>>
 {
     /**
      * Fetches a single page
      * @param page
      */
-    get(page: number): Promise<SingularResponse<M> | PluralResponse<M>>;
+    get(page: number): Promise<GET_RESPONSE>;
 
     /**
      * Fetches the first result available in the backend
@@ -28,25 +29,25 @@ export interface QueryMethods<M extends Model = Model>
      * @param {string} attribute - The attribute being tested
      * @param {string} value - The value the attribute should equal
      */
-    where(attribute: string, value: string): Builder<M>;
+    where(attribute: string, value: string): Builder<M, GET_RESPONSE>;
 
     /**
      * Specify a relation that should be joined and included in the returned object graph
      * @param {any} value
      */
-    with(value: any): Builder<M>;
+    with(value: any): Builder<M, GET_RESPONSE>;
 
     /**
      * Specify an attribute to sort by and the direction to sort in
      * @param {string} attribute - The attribute to sort by
      * @param {string direction - The direction to sort in
      */
-    orderBy(attribute: string, direction?: SortDirection|string): Builder<M>;
+    orderBy(attribute: string, direction?: SortDirection|string): Builder<M, GET_RESPONSE>;
 
     /**
      * Specify a custom query parameter to add to the resulting HTTP request URL
      * @param {string} queryParameter - The name of the parameter, e.g. 'a' in "http://foo.com?a=v"
      * @param {string} value - The value of the parameter, e.g. 'v' in "http://foo.com?a=v"
      */
-    option(queryParameter: string, value: string): Builder<M>;
+    option(queryParameter: string, value: string): Builder<M, GET_RESPONSE>;
 }

--- a/src/QueryMethods.ts
+++ b/src/QueryMethods.ts
@@ -2,50 +2,51 @@ import {Builder} from "./Builder";
 import {SingularResponse} from "./response/SingularResponse";
 import {PluralResponse} from "./response/PluralResponse";
 import {SortDirection} from "./SortDirection";
+import {Model} from "./Model";
 
-export interface QueryMethods
+export interface QueryMethods<M extends Model = Model>
 {
     /**
      * Fetches a single page
      * @param page
      */
-    get(page: number): Promise<SingularResponse | PluralResponse>;
+    get(page: number): Promise<SingularResponse<M> | PluralResponse<M>>;
 
     /**
      * Fetches the first result available in the backend
      */
-    first(): Promise<SingularResponse>;
+    first(): Promise<SingularResponse<M>>;
 
     /**
      * Fetches the result with the specified ID
      * @param id
      */
-    find(id: string | number): Promise<SingularResponse>;
+    find(id: string | number): Promise<SingularResponse<M>>;
 
     /**
      * Adds a "where equals" clause to the query
      * @param {string} attribute - The attribute being tested
      * @param {string} value - The value the attribute should equal
      */
-    where(attribute: string, value: string): Builder;
+    where(attribute: string, value: string): Builder<M>;
 
     /**
      * Specify a relation that should be joined and included in the returned object graph
      * @param {any} value
      */
-    with(value: any): Builder;
+    with(value: any): Builder<M>;
 
     /**
      * Specify an attribute to sort by and the direction to sort in
      * @param {string} attribute - The attribute to sort by
      * @param {string direction - The direction to sort in
      */
-    orderBy(attribute: string, direction?: SortDirection|string): Builder;
+    orderBy(attribute: string, direction?: SortDirection|string): Builder<M>;
 
     /**
      * Specify a custom query parameter to add to the resulting HTTP request URL
      * @param {string} queryParameter - The name of the parameter, e.g. 'a' in "http://foo.com?a=v"
      * @param {string} value - The value of the parameter, e.g. 'v' in "http://foo.com?a=v"
      */
-    option(queryParameter: string, value: string): Builder;
+    option(queryParameter: string, value: string): Builder<M>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,56 +1,30 @@
 /**
  * main
  */
-import { Model as _Model } from "./Model";
-export { _Model as Model };
-
-import { Builder as _Builder } from "./Builder";
-export { _Builder as Builder };
-
-import { PaginationStrategy as _PaginationStrategy } from "./PaginationStrategy";
-export { _PaginationStrategy as PaginationStrategy };
-
-import { SortDirection as _SortDirection } from "./SortDirection";
-export { _SortDirection as SortDirection };
+export { Model } from "./Model";
+export { Builder } from "./Builder";
+export { PaginationStrategy } from "./PaginationStrategy";
+export { SortDirection } from "./SortDirection";
 
 /**
  * httpclient
  */
-import { HttpClient as _HttpClient } from "./httpclient/HttpClient";
-export { _HttpClient as HttpClient };
-
-import { HttpClientPromise as _HttpClientPromise } from "./httpclient/HttpClientPromise";
-export { _HttpClientPromise as HttpClientPromise };
-
-import { HttpClientResponse as _HttpClientResponse } from "./httpclient/HttpClientResponse";
-export { _HttpClientResponse as HttpClientResponse };
+export { HttpClient } from "./httpclient/HttpClient";
+export { HttpClientPromise } from "./httpclient/HttpClientPromise";
+export { HttpClientResponse } from "./httpclient/HttpClientResponse";
 
 /**
  * relation
  */
-import { Relation as _Relation } from "./relation/Relation";
-export { _Relation as Relation };
-
-import { ToManyRelation as _ToManyRelation } from "./relation/ToManyRelation";
-export { _ToManyRelation as ToManyRelation };
-
-import { ToOneRelation as _ToOneRelation } from "./relation/ToOneRelation";
-export { _ToOneRelation as ToOneRelation };
+export { Relation } from "./relation/Relation";
+export { ToManyRelation } from "./relation/ToManyRelation";
+export { ToOneRelation } from "./relation/ToOneRelation";
 
 /**
  * response
  */
-import { Response as _Response } from "./response/Response";
-export { _Response as Response };
-
-import { RetrievalResponse as _RetrievalResponse } from "./response/RetrievalResponse";
-export { _RetrievalResponse as RetrievalResponse };
-
-import { SingularResponse as _SingularResponse } from "./response/SingularResponse";
-export { _SingularResponse as SingularResponse };
-
-import { PluralResponse as _PluralResponse } from "./response/PluralResponse";
-export { _PluralResponse as PluralResponse };
-
-import { SaveResponse as _SaveResponse } from "./response/SaveResponse";
-export { _SaveResponse as SaveResponse };
+export { Response } from "./response/Response";
+export { RetrievalResponse } from "./response/RetrievalResponse";
+export { SingularResponse } from "./response/SingularResponse";
+export { PluralResponse } from "./response/PluralResponse";
+export { SaveResponse } from "./response/SaveResponse";

--- a/src/relation/Relation.ts
+++ b/src/relation/Relation.ts
@@ -1,14 +1,14 @@
 import {Model} from "../Model";
 import {Reflection} from "../util/Reflection";
-export class Relation
+export class Relation<R extends Model = Model>
 {
     private relatedType;
 
-    private referringObject: Model | undefined;
+    private referringObject: R | undefined;
 
     private name: string;
 
-    constructor(relatedType, referringObject: Model | undefined = undefined, name: string | undefined = undefined)
+    constructor(relatedType, referringObject: R | undefined = undefined, name: string | undefined = undefined)
     {
         this.relatedType = relatedType;
         this.referringObject = referringObject;

--- a/src/relation/ToManyRelation.ts
+++ b/src/relation/ToManyRelation.ts
@@ -4,41 +4,42 @@ import {Builder} from "../Builder";
 import {PluralResponse} from "../response/PluralResponse";
 import {SingularResponse} from "../response/SingularResponse";
 import {SortDirection} from "../SortDirection";
+import {Model} from "../Model";
 
-export class ToManyRelation extends Relation implements QueryMethods
+export class ToManyRelation<M extends Model = Model, R extends Model = Model> extends Relation<R> implements QueryMethods<M>
 {
-    get(page?: number): Promise<PluralResponse> {
-        return <Promise<PluralResponse>> new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+    get(page?: number): Promise<PluralResponse<M>> {
+        return <Promise<PluralResponse<M>>> new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .get(page);
     }
 
-    first(): Promise<SingularResponse> {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+    first(): Promise<SingularResponse<M>> {
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .first();
     }
 
-    find(id: string | number): Promise<SingularResponse> {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+    find(id: string | number): Promise<SingularResponse<M>> {
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .find(id);
     }
 
-    where(attribute: string, value: string): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+    where(attribute: string, value: string): Builder<M> {
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .where(attribute, value);
     }
 
-    with(value: any): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+    with(value: any): Builder<M> {
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .with(value);
     }
 
-    public orderBy(attribute: string, direction?: SortDirection|string): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+    public orderBy(attribute: string, direction?: SortDirection|string): Builder<M> {
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .orderBy(attribute, direction);
     }
 
-    option(queryParameter: string, value: string): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+    option(queryParameter: string, value: string): Builder<M> {
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
             .option(queryParameter, value);
     }
 }

--- a/src/relation/ToManyRelation.ts
+++ b/src/relation/ToManyRelation.ts
@@ -6,7 +6,7 @@ import {SingularResponse} from "../response/SingularResponse";
 import {SortDirection} from "../SortDirection";
 import {Model} from "../Model";
 
-export class ToManyRelation<M extends Model = Model, R extends Model = Model> extends Relation<R> implements QueryMethods<M>
+export class ToManyRelation<M extends Model = Model, R extends Model = Model> extends Relation<R> implements QueryMethods<M, PluralResponse<M>>
 {
     get(page?: number): Promise<PluralResponse<M>> {
         return <Promise<PluralResponse<M>>> new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())

--- a/src/relation/ToOneRelation.ts
+++ b/src/relation/ToOneRelation.ts
@@ -4,41 +4,42 @@ import {Builder} from "../Builder";
 import {SingularResponse} from "../response/SingularResponse";
 import {QueryMethods} from "../QueryMethods";
 import {SortDirection} from "../SortDirection";
+import {Model} from "../Model";
 
-export class ToOneRelation extends Relation implements QueryMethods
+export class ToOneRelation<M extends Model = Model, R extends Model = Model> extends Relation<R> implements QueryMethods<M>
 {
-    get(page?: number): Promise<SingularResponse> {
-        return <Promise<SingularResponse>> new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+    get(page?: number): Promise<SingularResponse<M>> {
+        return <Promise<SingularResponse<M>>> new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .get(page);
     }
 
-    first(): Promise<SingularResponse> {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+    first(): Promise<SingularResponse<M>> {
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .first();
     }
 
-    find(id: string | number): Promise<SingularResponse> {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+    find(id: string | number): Promise<SingularResponse<M>> {
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .find(id);
     }
 
-    where(attribute: string, value: string): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+    where(attribute: string, value: string): Builder<M> {
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .where(attribute, value);
     }
 
-    with(value: any): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+    with(value: any): Builder<M> {
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .with(value);
     }
 
-    orderBy(attribute: string, direction?: SortDirection|string): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+    orderBy(attribute: string, direction?: SortDirection|string): Builder<M> {
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .orderBy(attribute, direction);
     }
 
-    option(queryParameter: string, value: string): Builder {
-        return new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+    option(queryParameter: string, value: string): Builder<M> {
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .option(queryParameter, value);
     }
 }

--- a/src/relation/ToOneRelation.ts
+++ b/src/relation/ToOneRelation.ts
@@ -6,40 +6,40 @@ import {QueryMethods} from "../QueryMethods";
 import {SortDirection} from "../SortDirection";
 import {Model} from "../Model";
 
-export class ToOneRelation<M extends Model = Model, R extends Model = Model> extends Relation<R> implements QueryMethods<M>
+export class ToOneRelation<M extends Model = Model, R extends Model = Model> extends Relation<R> implements QueryMethods<M, SingularResponse<M>>
 {
     get(page?: number): Promise<SingularResponse<M>> {
-        return <Promise<SingularResponse<M>>> new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .get(page);
     }
 
     first(): Promise<SingularResponse<M>> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .first();
     }
 
     find(id: string | number): Promise<SingularResponse<M>> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .find(id);
     }
 
-    where(attribute: string, value: string): Builder<M> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+    where(attribute: string, value: string): Builder<M, SingularResponse<M>> {
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .where(attribute, value);
     }
 
-    with(value: any): Builder<M> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+    with(value: any): Builder<M, SingularResponse<M>> {
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .with(value);
     }
 
-    orderBy(attribute: string, direction?: SortDirection|string): Builder<M> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+    orderBy(attribute: string, direction?: SortDirection|string): Builder<M, SingularResponse<M>> {
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .orderBy(attribute, direction);
     }
 
-    option(queryParameter: string, value: string): Builder<M> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+    option(queryParameter: string, value: string): Builder<M, SingularResponse<M>> {
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .option(queryParameter, value);
     }
 }

--- a/src/response/PluralResponse.ts
+++ b/src/response/PluralResponse.ts
@@ -2,13 +2,12 @@ import {RetrievalResponse} from "./RetrievalResponse";
 import {Model} from "../Model";
 import {Resource} from "../Resource";
 import {JsonApiResponseBody} from "../JsonApiResponseBody";
-import {AxiosResponse} from "axios";
 import {HttpClientResponse} from "../httpclient/HttpClientResponse";
 import {Query} from "../Query";
 
-export class PluralResponse extends RetrievalResponse
+export class PluralResponse<M extends Model = Model> extends RetrievalResponse<M>
 {
-    protected data: Model[];
+    protected data: M[];
 
     protected pageNumber: number;
 
@@ -31,7 +30,7 @@ export class PluralResponse extends RetrievalResponse
         return Math.max(this.pageNumber, 1);
     }
 
-    public getData(): Model[]
+    public getData(): M[]
     {
         if (this.limit !== undefined && Array.isArray(this.data)){
             return this.data.slice(0, this.limit);

--- a/src/response/RetrievalResponse.ts
+++ b/src/response/RetrievalResponse.ts
@@ -11,15 +11,15 @@ import {AxiosResponse} from "axios";
 import {HttpClientResponse} from "../httpclient/HttpClientResponse";
 import {Query} from "../Query";
 
-export abstract class RetrievalResponse extends Response
+export abstract class RetrievalResponse<M extends Model = Model> extends Response
 {
     protected modelType: any;
 
     protected resourceIndex: Map<Map<Resource>>;
 
-    protected modelIndex: Map<Map<Model>>;
+    protected modelIndex: Map<Map<M>>;
 
-    protected included: Model[];
+    protected included: M[];
 
     constructor(
         query: Query,
@@ -30,7 +30,7 @@ export abstract class RetrievalResponse extends Response
         super(query, httpClientResponse);
         this.modelType = modelType;
         this.resourceIndex = new Map<Map<Resource>>();
-        this.modelIndex = new Map<Map<Model>>();
+        this.modelIndex = new Map<Map<M>>();
 
         // Index the JsonApiDocs
         this.indexIncludedDocs(responseBody.included);
@@ -77,9 +77,9 @@ export abstract class RetrievalResponse extends Response
         let type = doc.type;
         let id = doc.id;
         if (!this.modelIndex.get(type)) {
-            this.modelIndex.set(type, new Map<Model>());
+            this.modelIndex.set(type, new Map<M>());
         }
-        let model: Model = new modelType();
+        let model: M = new modelType();
         model.populateFromResource(doc);
         this.modelIndex.get(type).set(id, model);
         for (let resourceRelationName in {...includeTree, ...doc.relationships}) {
@@ -90,7 +90,7 @@ export abstract class RetrievalResponse extends Response
             }
 
             const includeSubtree = includeTree ? includeTree[resourceRelationName] : {};
-            let relation: Relation = model[modelRelationName]();
+            let relation: Relation<Model> = model[modelRelationName]();
             if (relation instanceof ToManyRelation) {
                 let relatedStubs: ResourceStub[] = (doc.relationships !== undefined && doc.relationships[resourceRelationName] !== undefined)
                     ?

--- a/src/response/SaveResponse.ts
+++ b/src/response/SaveResponse.ts
@@ -3,9 +3,9 @@ import {Response} from "./Response";
 import {JsonApiResponseBody} from "../JsonApiResponseBody";
 import {HttpClientResponse} from "../httpclient/HttpClientResponse";
 
-export class SaveResponse extends Response
+export class SaveResponse<M extends Model = Model> extends Response
 {
-    protected readonly model: Model | null;
+    protected readonly model: M | null;
 
     constructor(
         httpClientResponse: HttpClientResponse,

--- a/src/response/SingularResponse.ts
+++ b/src/response/SingularResponse.ts
@@ -5,9 +5,9 @@ import {JsonApiResponseBody} from "../JsonApiResponseBody";
 import {HttpClientResponse} from "../httpclient/HttpClientResponse";
 import {Query} from "../Query";
 
-export class SingularResponse extends RetrievalResponse
+export class SingularResponse<M extends Model = Model> extends RetrievalResponse<M>
 {
-    protected data: Model | null;
+    protected data: M | null;
 
     constructor(
         query: Query,
@@ -18,7 +18,7 @@ export class SingularResponse extends RetrievalResponse
         super(query, httpClientResponse, modelType, responseBody);
     }
 
-    public getData(): Model | null
+    public getData(): M | null
     {
         return this.data;
     }

--- a/tests/Builder.test.ts
+++ b/tests/Builder.test.ts
@@ -720,7 +720,7 @@ describe('Builder', () => {
             .query()
             .with('foes')
             .get()
-            .then((response: PluralResponse) => {
+            .then(response => {
                 let beefMan: Hero = <Hero> response.getData()[0];
                 let foes = beefMan.getFoes();
                 assert(foes !== undefined);


### PR DESCRIPTION
This is a typing improvement for TypeScript users, so the Model type is defined as a Generic inside the API.

This should avoid to manually cast the retrieved data.

Given we have a `User` and `Role` model, with a relationship between them.

```typescript
import { Model } from 'coloquent'
import { ToManyRelation } from 'coloquent/dist/relation/ToManyRelation'

export class Role extends Model {
  public getJsonApiBaseUrl (): string {
    return "http://testing.tld/jsonapi"
  }

  protected jsonApiType = 'role'

  getKey (): string {
    return this.getAttribute('key')
  }
}

export class User extends Model {
  public getJsonApiBaseUrl (): string {
    return "http://testing.tld/jsonapi"
  }

  protected jsonApiType = 'user'

  getDisplayName (): string {
    return this.getAttribute('display_name')
  }

  getRoles(): ToManyRelation<Role, this> { // Note the generics here, 1st parameter is the type of the related objects, and second parameter is the related type.
    return this.getRelation("role")
  }
}
```

You can know invoke User.get() and others static method with the model generic type, for TypeScript to achive better inference while writting coloquent code.

```typescript
const users = await User.get<User>() // Due to TypeScript limitations, we have to specify the model class name again as a generic here.
const displayNames = users.getData().map((u) => u.getDisplayName()) // getData() is inferred as User[] instead of Model[], so getDisplayName() is available without casting.
console.log(displayNames)

// Then we don't need to cast anything else, because Relations are generically typed now.
const roles = await users.getData()[0].getRoles().get()
const keys = roles.getData().map((r) => r.getKey())
console.log(keys)
```

Note that all introduced generics are optional, so it's not a breaking change for TypeScript users.