### PR TITLE
Allow to extend Model with Proxy

### DIFF
--- a/src/Model.ts
+++ b/src/Model.ts
@@ -223,7 +223,7 @@ export abstract class Model
                 (response: HttpClientResponse) => {
                     const idFromJson: string | undefined = response.getData().data.id;
                     this.setApiId(idFromJson);
-                    return new SaveResponse(response, this.constructor, response.getData());
+                    return new SaveResponse(response, Object.getPrototypeOf(this).constructor, response.getData());
                 },
                 (response: AxiosError) => {
                     throw response;
@@ -243,7 +243,7 @@ export abstract class Model
                 (response: HttpClientResponse) => {
                     const idFromJson: string | undefined = response.getData().data.id;
                     this.setApiId(idFromJson);
-                    return new SaveResponse(response, this.constructor, response.getData());
+                    return new SaveResponse(response, Object.getPrototypeOf(this).constructor, response.getData());
                 },
                 function (response: AxiosError) {
                     throw response;


### PR DESCRIPTION
Currently, when extending model using a Proxy it raises an error when saving, since it can't call the `Model.populateFromResource` method (`this.constructor` returns the Proxy prototype and not the model one).

Example model:

```
class Model extends BaseModel {
	constructor() {
		super();
		return new Proxy(this, {
			get: () => ...,
			set: () => ...
		}
}
```