### PR TITLE
Configurable HttpClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,8 @@ import {Model} from 'coloquent';
 
 class Artist extends Model
 {
-    public getJsonApiBaseUrl(): string
-    {
-        return 'http://www.app.com/api/';
-    }
-    
-    protected jsonApiType = 'artists';
-    
+    protected static jsonApiBaseUrl = 'http://www.app.com/api';
+    protected static jsonApiType = 'artists';   
     protected pageSize = 30;
 }
 ```
@@ -151,15 +146,12 @@ import {Model, ToManyRelation, ToOneRelation} from 'coloquent';
 
 abstract class AppModel extends Model
 {
-    getJsonApiBaseUrl(): string
-    {
-        return 'http://www.app.com/api/';
-    }
+    protected static jsonApiBaseUrl = 'http://www.app.com/api';
 }
 
 class Artist extends AppModel
 {
-    jsonApiType = 'artists';
+    protected static jsonApiType = 'artists';
     
     readOnlyAttributes = [
         'age'
@@ -198,7 +190,7 @@ class Artist extends AppModel
 
 class Album extends AppModel
 {
-    jsonApiType = 'albums';
+    protected static jsonApiType = 'albums';
 
     artist(): ToOneRelation<Artist, this>
     {
@@ -223,7 +215,7 @@ class Album extends AppModel
 
 class Song extends AppModel
 {
-    jsonApiType = 'songs';
+    protected static jsonApiType = 'songs';
 
     album(): ToOneRelation<Album, this>
     {

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ import {Model} from 'coloquent';
 
 class Artist extends Model
 {
-    protected static jsonApiBaseUrl = 'http://www.app.com/api';
-    protected static jsonApiType = 'artists';   
-    protected pageSize = 30;
+    static jsonApiBaseUrl = 'http://www.app.com/api'
+    static jsonApiType = 'artists'
+    static pageSize = 30
 }
 ```
 
@@ -146,12 +146,12 @@ import {Model, ToManyRelation, ToOneRelation} from 'coloquent';
 
 abstract class AppModel extends Model
 {
-    protected static jsonApiBaseUrl = 'http://www.app.com/api';
+    static jsonApiBaseUrl = 'http://www.app.com/api'
 }
 
 class Artist extends AppModel
 {
-    protected static jsonApiType = 'artists';
+    static jsonApiType = 'artists'
     
     readOnlyAttributes = [
         'age'
@@ -190,7 +190,7 @@ class Artist extends AppModel
 
 class Album extends AppModel
 {
-    protected static jsonApiType = 'albums';
+    static jsonApiType = 'albums'
 
     artist(): ToOneRelation<Artist, this>
     {
@@ -215,7 +215,7 @@ class Album extends AppModel
 
 class Song extends AppModel
 {
-    protected static jsonApiType = 'songs';
+    static jsonApiType = 'songs'
 
     album(): ToOneRelation<Album, this>
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coloquent",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -866,9 +866,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "moxios": "^0.4.0",
     "rimraf": "^3.0.0",
     "ts-node": "^8.4.1",
-    "typescript": "^3.6.4"
+    "typescript": "^4.5.4"
   }
 }

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -55,7 +55,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
         clone.getQuery().getPaginationSpec().setPage(page);
         if (this.forceSingular) {
             return this.getHttpClient()
-                .get(this.baseUrl + clone.getQuery().toString())
+                .get(this.baseUrl + '/' + clone.getQuery().toString())
                 .then(
                     (response: HttpClientResponse) => {
                         return new SingularResponse(clone.getQuery(), response, this.modelType, response.getData()) as unknown as GET_RESPONSE;
@@ -66,7 +66,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
                 );
         } else {
             return this.getHttpClient()
-                .get(this.baseUrl + clone.getQuery().toString())
+                .get(this.baseUrl + '/' + clone.getQuery().toString())
                 .then(
                     (response: HttpClientResponse) => {
                         return new PluralResponse(clone.getQuery(), response, this.modelType, response.getData(), page) as unknown as GET_RESPONSE;
@@ -83,7 +83,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
         const clone = this.clone();
         clone.getQuery().getPaginationSpec().setPageLimit(1);
         return <Promise<SingularResponse<M>>> this.getHttpClient()
-            .get(this.baseUrl + clone.getQuery().toString())
+            .get(this.baseUrl + '/' + clone.getQuery().toString())
             .then(
                 (response: HttpClientResponse) => {
                     return new SingularResponse(this.query, response, this.modelType, response.getData());
@@ -105,7 +105,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
         const clone = this.clone();
         clone.query.setIdToFind(id);
         return <Promise<SingularResponse<M>>> clone.getHttpClient()
-            .get(this.baseUrl + clone.getQuery().toString())
+            .get(this.baseUrl + '/' + clone.getQuery().toString())
             .then(
                 (response: HttpClientResponse) => {
                     return new SingularResponse(clone.getQuery(), response, this.modelType, response.getData());

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -220,7 +220,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
                 new OffsetBasedPaginationSpec(
                     this.modelType.getPaginationOffsetParamName(),
                     this.modelType.getPaginationLimitParamName(),
-                    this.modelType.getPageSize()
+                    this.modelType.pageSize
                 )
             );
         } else if (paginationStrategy === PaginationStrategy.PageBased) {
@@ -228,7 +228,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
                 new PageBasedPaginationSpec(
                     this.modelType.getPaginationPageNumberParamName(),
                     this.modelType.getPaginationPageSizeParamName(),
-                    this.modelType.getPageSize()
+                    this.modelType.pageSize
                 )
             );
         } else {

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -42,7 +42,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
         this.baseUrl = modelType.effectiveJsonApiBaseUrl;
         baseModelJsonApiType = baseModelJsonApiType
             ? baseModelJsonApiType
-            : modelType.getJsonApiType();
+            : modelType.effectiveJsonApiType;
         this.query = new Query(baseModelJsonApiType, queriedRelationName, baseModelJsonApiId);
         this.initPaginationSpec();
         this.httpClient = modelType.getHttpClient();

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -40,10 +40,9 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
     ) {
         this.modelType = modelType;
         this.baseUrl = modelType.getJsonApiBaseUrl();
-        let modelInstance: M = (new (<any> modelType)());
         baseModelJsonApiType = baseModelJsonApiType
             ? baseModelJsonApiType
-            : modelInstance.getJsonApiType();
+            : modelType.getJsonApiType();
         this.query = new Query(baseModelJsonApiType, queriedRelationName, baseModelJsonApiId);
         this.initPaginationSpec();
         this.httpClient = modelType.getHttpClient();

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -39,7 +39,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
         forceSingular: boolean = false
     ) {
         this.modelType = modelType;
-        this.baseUrl = modelType.getJsonApiBaseUrl();
+        this.baseUrl = modelType.effectiveJsonApiBaseUrl;
         baseModelJsonApiType = baseModelJsonApiType
             ? baseModelJsonApiType
             : modelType.getJsonApiType();

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -17,6 +17,8 @@ import {RetrievalResponse} from "./response/RetrievalResponse";
 
 export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResponse<M> = PluralResponse<M>> implements QueryMethods<M, GET_RESPONSE>
 {
+    protected readonly baseUrl: string;
+
     protected readonly modelType: any;
 
     private readonly httpClient: HttpClient;
@@ -37,6 +39,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
         forceSingular: boolean = false
     ) {
         this.modelType = modelType;
+        this.baseUrl = modelType.getJsonApiBaseUrl();
         let modelInstance: M = (new (<any> modelType)());
         baseModelJsonApiType = baseModelJsonApiType
             ? baseModelJsonApiType
@@ -53,7 +56,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
         clone.getQuery().getPaginationSpec().setPage(page);
         if (this.forceSingular) {
             return this.getHttpClient()
-                .get(clone.getQuery().toString())
+                .get(this.baseUrl + clone.getQuery().toString())
                 .then(
                     (response: HttpClientResponse) => {
                         return new SingularResponse(clone.getQuery(), response, this.modelType, response.getData()) as unknown as GET_RESPONSE;
@@ -64,7 +67,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
                 );
         } else {
             return this.getHttpClient()
-                .get(clone.getQuery().toString())
+                .get(this.baseUrl + clone.getQuery().toString())
                 .then(
                     (response: HttpClientResponse) => {
                         return new PluralResponse(clone.getQuery(), response, this.modelType, response.getData(), page) as unknown as GET_RESPONSE;
@@ -81,7 +84,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
         const clone = this.clone();
         clone.getQuery().getPaginationSpec().setPageLimit(1);
         return <Promise<SingularResponse<M>>> this.getHttpClient()
-            .get(this.query.toString())
+            .get(this.baseUrl + clone.getQuery().toString())
             .then(
                 (response: HttpClientResponse) => {
                     return new SingularResponse(this.query, response, this.modelType, response.getData());
@@ -103,7 +106,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
         const clone = this.clone();
         clone.query.setIdToFind(id);
         return <Promise<SingularResponse<M>>> clone.getHttpClient()
-            .get(clone.getQuery().toString())
+            .get(this.baseUrl + clone.getQuery().toString())
             .then(
                 (response: HttpClientResponse) => {
                     return new SingularResponse(clone.getQuery(), response, this.modelType, response.getData());
@@ -163,7 +166,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
                 direction === SortDirection.ASC
             )
         );
-        
+
         return clone;
     }
 

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -45,7 +45,7 @@ export class Builder<M extends Model = Model, GET_RESPONSE extends RetrievalResp
             : modelType.effectiveJsonApiType;
         this.query = new Query(baseModelJsonApiType, queriedRelationName, baseModelJsonApiId);
         this.initPaginationSpec();
-        this.httpClient = modelType.getHttpClient();
+        this.httpClient = modelType.effectiveHttpClient;
         this.forceSingular = forceSingular;
     }
 

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -19,8 +19,6 @@ export interface Model {
 }
 export abstract class Model
 {
-    private type: string;
-
     /**
      * @type {number} the page size
      */
@@ -87,7 +85,6 @@ export abstract class Model
 
     constructor()
     {
-        this.type = typeof this;
         this.relations = new Map();
         this.attributes = new Map();
         this.readOnlyAttributes = [];

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -181,7 +181,7 @@ export abstract class Model
 
         let payload = {
             data: {
-                type: this.getJsonApiType(),
+                type: (this as Model).constructor.getJsonApiType(),
                 attributes,
                 relationships
             }
@@ -194,7 +194,7 @@ export abstract class Model
 
     private serializeRelatedModel(model: Model): any {
         return {
-            type: model.getJsonApiType(),
+            type: model.constructor.getJsonApiType(),
             id: model.id
         };
     }
@@ -218,9 +218,9 @@ export abstract class Model
         }
 
         let payload = this.serialize();
-        return this.getHttpClient()
+        return (this as Model).constructor.getHttpClient()
             .patch(
-                this.constructor.getJsonApiUrl()+'/'+this.id,
+                (this as Model).constructor.getJsonApiUrl()+'/'+this.id,
                 payload
             )
             .then(
@@ -238,9 +238,9 @@ export abstract class Model
     public create(): Promise<SaveResponse<this>>
     {
         let payload = this.serialize();
-        return this.getHttpClient()
+        return (this as Model).constructor.getHttpClient()
             .post(
-                this.constructor.getJsonApiUrl(),
+                (this as Model).constructor.getJsonApiUrl(),
                 payload
             )
             .then(
@@ -260,8 +260,8 @@ export abstract class Model
         if (!this.hasId) {
             throw new Error('Cannot delete a model with no ID.');
         }
-        return this.getHttpClient()
-            .delete(this.constructor.getJsonApiUrl()+'/'+this.id)
+        return (this as Model).constructor.getHttpClient()
+            .delete((this as Model).constructor.getJsonApiUrl()+'/'+this.id)
             .then(function () {});
     }
 
@@ -358,21 +358,21 @@ export abstract class Model
      * @deprecated Use the static method with the same name instead
      */
     public getJsonApiType(): string {
-      return this.constructor.getJsonApiType()
+      return (this as Model).constructor.getJsonApiType()
     }
 
     /**
      * @deprecated Use the static method with the same name instead
      */
     public getJsonApiBaseUrl(): string {
-      return this.constructor.getJsonApiBaseUrl()
+      return (this as Model).constructor.getJsonApiBaseUrl()
     }
 
     /**
      * @deprecated Use the static method with the same name instead
      */
     public getHttpClient(): HttpClient {
-      return this.constructor.getHttpClient()
+      return (this as Model).constructor.getHttpClient()
     }
 
     public populateFromResource(resource: Resource): void

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -350,12 +350,16 @@ export abstract class Model
       return this.httpClient
     }
 
-    // Backward compatibility.
+    /**
+     * @deprecated Use the static method with the same name instead
+     */
     public getJsonApiType(): string {
       return this.constructor.getJsonApiType()
     }
 
-    // Backward compatibility.
+    /**
+     * @deprecated Use the static method with the same name instead
+     */
     public getJsonApiBaseUrl(): string {
       return this.constructor.getJsonApiBaseUrl()
     }

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -63,9 +63,12 @@ export abstract class Model
     private static _effectiveJsonApiBaseUrl: string | undefined;
 
     /**
-     * The JSON-API type, choose plural, lowercase alphabetic only, e.g. 'artists'
+     * The JSON-API type, choose plural, lowercase alphabetic only, e.g. 'artists'.
+     * Required property. If not set, Colu
      */
     protected static jsonApiType: string | undefined;
+
+    private static _effectiveJsonApiType: string | undefined;
 
     /**
      * The endpoint. If this is not set on a type, the endpoint is constructed from
@@ -172,7 +175,7 @@ export abstract class Model
 
         let payload = {
             data: {
-                type: (this as Model).constructor.getJsonApiType(),
+                type: (this as Model).constructor.effectiveJsonApiType,
                 attributes,
                 relationships
             }
@@ -185,7 +188,7 @@ export abstract class Model
 
     private serializeRelatedModel(model: Model): any {
         return {
-            type: model.constructor.getJsonApiType(),
+            type: model.constructor.effectiveJsonApiType,
             id: model.id
         };
     }
@@ -331,15 +334,20 @@ export abstract class Model
       return this._effectiveJsonApiBaseUrl;
     }
 
-    public static getJsonApiType(): string {
-      if (this.jsonApiType === undefined) {
-        throw new Error(`Expected ${this.name} to have property expect jsonApiType defined`)
-      }
-      return this.jsonApiType;
+    public static get effectiveJsonApiType(): string {
+        if (this._effectiveJsonApiType === undefined) {
+            if (this.jsonApiType === undefined) {
+                throw new Error(
+                    `Expected ${this.name} to have property expect jsonApiType defined`
+                );
+            }
+            this._effectiveJsonApiType = this.jsonApiType;
+        }
+        return this._effectiveJsonApiType;
     }
 
     private static getEndpoint(): string {
-        return (this.endpoint ?? this.getJsonApiType()).replace(/^\/+/, '');
+        return (this.endpoint ?? this.effectiveJsonApiType).replace(/^\/+/, '');
     }
 
     public static getJsonApiUrl(): string {
@@ -358,7 +366,7 @@ export abstract class Model
      * @deprecated Use the static method with the same name instead
      */
     public getJsonApiType(): string {
-      return (this as Model).constructor.getJsonApiType()
+      return (this as Model).constructor.effectiveJsonApiType;
     }
 
     /**

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -20,32 +20,32 @@ export interface Model {
 export abstract class Model
 {
     /**
-     * @type {number} the page size
+     * The page size
      */
     protected static pageSize: number = 50;
 
     /**
-     * @type {PaginationStrategy} the pagination strategy
+     * The pagination strategy
      */
     protected static paginationStrategy: PaginationStrategy = PaginationStrategy.OffsetBased;
 
     /**
-     * @type {string} The number query parameter name. By default: 'page[number]'
+     * The number query parameter name. By default: 'page[number]'
      */
     protected static paginationPageNumberParamName: string = 'page[number]';
 
     /**
-     * @type {string} The size query parameter name. By default: 'page[size]'
+     * The size query parameter name. By default: 'page[size]'
      */
     protected static paginationPageSizeParamName: string = 'page[size]';
 
     /**
-     * @type {string} The offset query parameter name. By default: 'page[offset]'
+     * The offset query parameter name. By default: 'page[offset]'
      */
     protected static paginationOffsetParamName: string = 'page[offset]';
 
     /**
-     * @type {string} The limit query parameter name. By default: 'page[limit]'
+     * The limit query parameter name. By default: 'page[limit]'
      */
     protected static paginationLimitParName: string = 'page[limit]';
 
@@ -56,17 +56,17 @@ export abstract class Model
     private attributes: Map<any>;
 
     /**
-     * @type {string} The model endpoint base URL, e.g 'http://localhost:3000/api/v1'
+     * The model endpoint base URL, e.g 'http://localhost:3000/api/v1'.
      */
     protected static jsonApiBaseUrl: string | undefined;
 
     /**
-     * @type {string} The JSON-API type, choose plural, lowercase alphabetic only, e.g. 'artists'
+     * The JSON-API type, choose plural, lowercase alphabetic only, e.g. 'artists'
      */
     protected static jsonApiType: string | undefined;
 
     /**
-     * @type {string} The endpoint. If this is not set on a type, the endpoint is constructed from
+     * The endpoint. If this is not set on a type, the endpoint is constructed from
      * {@link Model.jsonApiType} by prepending it with a slash (i.e. "/jsonApiType").
      */
     protected static endpoint: string | undefined;

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -77,9 +77,9 @@ export abstract class Model
      */
     protected static httpClient: HttpClient;
 
-    protected readOnlyAttributes: string[] = [];
+    protected static readOnlyAttributes: string[] = [];
 
-    protected dates: {[key: string]: string} = {};
+    protected static dates: {[key: string]: string} = {};
 
     private static dateFormatter: DateFormatter | undefined;
 
@@ -154,7 +154,7 @@ export abstract class Model
     {
         let attributes = {};
         for (let key in this.attributes.toArray()) {
-            if (this.readOnlyAttributes.indexOf(key) == -1) {
+            if ((this as Model).constructor.readOnlyAttributes.indexOf(key) == -1) {
                 attributes[key] = this.attributes.get(key);
             }
         }
@@ -441,7 +441,7 @@ export abstract class Model
 
     private isDateAttribute(attributeName: string): boolean
     {
-        return this.dates.hasOwnProperty(attributeName);
+        return (this as Model).constructor.dates.hasOwnProperty(attributeName);
     }
 
     protected setAttribute(attributeName: string, value: any): void
@@ -450,7 +450,7 @@ export abstract class Model
             if (!Date.parse(value)) {
                 throw new Error(`${value} cannot be cast to type Date`);
             }
-            value = (<any> Model.getDateFormatter()).parseDate(value, this.dates[attributeName]);
+            value = (<any> Model.getDateFormatter()).parseDate(value, (this as Model).constructor.dates[attributeName]);
         }
 
         this.attributes.set(attributeName, value);

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -331,7 +331,8 @@ export abstract class Model
       if (this.jsonApiBaseUrl === undefined) {
         throw new Error(`Expected ${this.name} to have property expect jsonApiBaseUrl defined`)
       }
-      return this.jsonApiBaseUrl;
+
+      return this.jsonApiBaseUrl.replace(/\/+$/, '');
     }
 
     public static getJsonApiType(): string {
@@ -342,11 +343,11 @@ export abstract class Model
     }
 
     private static getEndpoint(): string {
-        return this.endpoint ?? `/${this.getJsonApiType()}`;
+        return (this.endpoint ?? this.getJsonApiType()).replace(/^\/+/, '');
     }
 
     public static getJsonApiUrl(): string {
-      return `${this.getJsonApiBaseUrl()}${this.getEndpoint()}`
+      return `${this.getJsonApiBaseUrl()}/${this.getEndpoint()}`
     }
 
     public static getHttpClient(): HttpClient

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -81,7 +81,7 @@ export abstract class Model
 
     protected dates: {[key: string]: string} = {};
 
-    private static dateFormatter;
+    private static dateFormatter: DateFormatter | undefined;
 
     /**
      * Get a {@link Builder} instance from a {@link Model} instance

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -322,15 +322,15 @@ export abstract class Model
     }
 
     public static getJsonApiBaseUrl(): string {
-      if (!this.jsonApiBaseUrl) {
-        throw new Error(`Expect ${this.name} to have property expect jsonApiBaseUrl defined`)
+      if (this.jsonApiBaseUrl === undefined) {
+        throw new Error(`Expected ${this.name} to have property expect jsonApiBaseUrl defined`)
       }
       return this.jsonApiBaseUrl
     }
 
     public static getJsonApiType(): string {
-      if (!this.jsonApiType) {
-        throw new Error(`Expect ${this.name} to have property expect jsonApiType defined`)
+      if (this.jsonApiType === undefined) {
+        throw new Error(`Expected ${this.name} to have property expect jsonApiType defined`)
       }
       return this.jsonApiType
     }

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -60,6 +60,8 @@ export abstract class Model
      */
     protected static jsonApiBaseUrl: string | undefined;
 
+    private static _effectiveJsonApiBaseUrl: string | undefined;
+
     /**
      * The JSON-API type, choose plural, lowercase alphabetic only, e.g. 'artists'
      */
@@ -316,12 +318,17 @@ export abstract class Model
         return relationNames;
     }
 
-    public static getJsonApiBaseUrl(): string {
-      if (this.jsonApiBaseUrl === undefined) {
-        throw new Error(`Expected ${this.name} to have property expect jsonApiBaseUrl defined`)
+    /**
+     * The base URL that is used to call the API
+     */
+    public static get effectiveJsonApiBaseUrl(): string {
+      if (this._effectiveJsonApiBaseUrl === undefined) {
+          if (this.jsonApiBaseUrl === undefined) {
+              throw new Error(`Expected ${this.name} to have static property 'jsonApiBaseUrl' defined`)
+          }
+          this._effectiveJsonApiBaseUrl = this.jsonApiBaseUrl.replace(/\/+$/, '');
       }
-
-      return this.jsonApiBaseUrl.replace(/\/+$/, '');
+      return this._effectiveJsonApiBaseUrl;
     }
 
     public static getJsonApiType(): string {
@@ -336,7 +343,7 @@ export abstract class Model
     }
 
     public static getJsonApiUrl(): string {
-      return `${this.getJsonApiBaseUrl()}/${this.getEndpoint()}`
+      return `${this.effectiveJsonApiBaseUrl}/${this.getEndpoint()}`
     }
 
     public static getHttpClient(): HttpClient
@@ -355,10 +362,11 @@ export abstract class Model
     }
 
     /**
-     * @deprecated Use the static method with the same name instead
+     * @deprecated Use the static property {@link jsonApiBaseUrl} or
+     * {@link effectiveJsonApiBaseUrl}
      */
     public getJsonApiBaseUrl(): string {
-      return (this as Model).constructor.getJsonApiBaseUrl()
+      return (this as Model).constructor.effectiveJsonApiBaseUrl;
     }
 
     /**

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -68,6 +68,12 @@ export abstract class Model
     protected static jsonApiType: string;
 
     /**
+     * @type {string} The endpoint. If this is not set on a type, the endpoint is constructed from
+     * {@link Model.jsonApiType} by prepending it with a slash (i.e. "/jsonApiType").
+     */
+    protected static endpoint?: string;
+
+    /**
      * @type {HttpClient} The HTTP client used to perform request for this model.
      * By default: {@link AxiosHttpClient}
      */
@@ -336,9 +342,7 @@ export abstract class Model
     }
 
     public static getJsonApiUrl(): string {
-      // TODO: Allow to explicitly set the endpoint.
-      // E.g: const path = this.endpoint || `/${this.getJsonApiType()}`
-      const path = `/${this.getJsonApiType()}`
+      const path = this.endpoint ?? `/${this.getJsonApiType()}`;
       return `${this.getJsonApiBaseUrl()}${path}`
     }
 

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -400,6 +400,9 @@ export abstract class Model
         }
     }
 
+    /**
+     * @deprecated Access the static {@link pageSize} property directly
+     */
     public static getPageSize(): number
     {
         return this.pageSize;

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -71,8 +71,8 @@ export abstract class Model
     private static _effectiveJsonApiType: string | undefined;
 
     /**
-     * The endpoint. If this is not set on a type, the endpoint is constructed from
-     * {@link Model.jsonApiType} by prepending it with a slash (i.e. "/jsonApiType").
+     * The endpoint. Optional. If not set, the {@link Model.jsonApiType}
+     * prepended with a slash (e.g. "/cars") will be used.
      */
     protected static endpoint: string | undefined;
 
@@ -348,12 +348,12 @@ export abstract class Model
         return this._effectiveJsonApiType;
     }
 
-    private static getEndpoint(): string {
+    private static get effectiveEndpoint(): string {
         return (this.endpoint ?? this.effectiveJsonApiType).replace(/^\/+/, '');
     }
 
     public static getJsonApiUrl(): string {
-      return `${this.effectiveJsonApiBaseUrl}/${this.getEndpoint()}`
+      return `${this.effectiveJsonApiBaseUrl}/${this.effectiveEndpoint}`
     }
 
     /**

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -364,6 +364,9 @@ export abstract class Model
       return this.constructor.getJsonApiBaseUrl()
     }
 
+    /**
+     * @deprecated Use the static method with the same name instead
+     */
     public getHttpClient(): HttpClient {
       return this.constructor.getHttpClient()
     }

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -60,18 +60,18 @@ export abstract class Model
     /**
      * @type {string} The model endpoint base URL, e.g 'http://localhost:3000/api/v1'
      */
-    protected static jsonApiBaseUrl: string;
+    protected static jsonApiBaseUrl: string | undefined;
 
     /**
      * @type {string} The JSON-API type, choose plural, lowercase alphabetic only, e.g. 'artists'
      */
-    protected static jsonApiType: string;
+    protected static jsonApiType: string | undefined;
 
     /**
      * @type {string} The endpoint. If this is not set on a type, the endpoint is constructed from
      * {@link Model.jsonApiType} by prepending it with a slash (i.e. "/jsonApiType").
      */
-    protected static endpoint?: string;
+    protected static endpoint: string | undefined;
 
     /**
      * @type {HttpClient} The HTTP client used to perform request for this model.
@@ -331,19 +331,22 @@ export abstract class Model
       if (this.jsonApiBaseUrl === undefined) {
         throw new Error(`Expected ${this.name} to have property expect jsonApiBaseUrl defined`)
       }
-      return this.jsonApiBaseUrl
+      return this.jsonApiBaseUrl;
     }
 
     public static getJsonApiType(): string {
       if (this.jsonApiType === undefined) {
         throw new Error(`Expected ${this.name} to have property expect jsonApiType defined`)
       }
-      return this.jsonApiType
+      return this.jsonApiType;
+    }
+
+    private static getEndpoint(): string {
+        return this.endpoint ?? `/${this.getJsonApiType()}`;
     }
 
     public static getJsonApiUrl(): string {
-      const path = this.endpoint ?? `/${this.getJsonApiType()}`;
-      return `${this.getJsonApiBaseUrl()}${path}`
+      return `${this.getJsonApiBaseUrl()}${this.getEndpoint()}`
     }
 
     public static getHttpClient(): HttpClient

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -65,7 +65,7 @@ export abstract class Model
     /**
      * @type {string} The JSON-API type, choose plural, lowercase alphabetic only, e.g. 'artists'
      */
-     protected static jsonApiType: string;
+    protected static jsonApiType: string;
 
     /**
      * @type {HttpClient} The HTTP client used to perform request for this model.

--- a/src/Model.ts
+++ b/src/Model.ts
@@ -51,9 +51,9 @@ export abstract class Model
 
     private id: string | undefined;
 
-    private relations: Map<any>;
+    private readonly relations = new Map<any>();
 
-    private attributes: Map<any>;
+    private readonly attributes = new Map<any>();
 
     /**
      * The model endpoint base URL, e.g 'http://localhost:3000/api/v1'.
@@ -77,19 +77,11 @@ export abstract class Model
      */
     protected static httpClient: HttpClient;
 
-    protected readOnlyAttributes: string[];
+    protected readOnlyAttributes: string[] = [];
 
-    protected dates: {[key: string]: string};
+    protected dates: {[key: string]: string} = {};
 
     private static dateFormatter;
-
-    constructor()
-    {
-        this.relations = new Map();
-        this.attributes = new Map();
-        this.readOnlyAttributes = [];
-        this.dates = {};
-    }
 
     /**
      * Get a {@link Builder} instance from a {@link Model} instance

--- a/src/httpclient/HttpClient.ts
+++ b/src/httpclient/HttpClient.ts
@@ -1,8 +1,6 @@
 import {HttpClientPromise} from "./HttpClientPromise";
 export interface HttpClient
 {
-    setBaseUrl(baseUrl: string): void
-
     /**
      * `withCredentials` indicates whether or not cross-site Access-Control requests
      * should be made using credentials

--- a/src/httpclient/axios/AxiosHttpClient.ts
+++ b/src/httpclient/axios/AxiosHttpClient.ts
@@ -9,7 +9,6 @@ export class AxiosHttpClient implements HttpClient
     private axiosInstance: AxiosInstance;
     private withCredentials: boolean;
 
-    constructor()
     constructor(axiosInstance?: AxiosInstance) {
         if (axiosInstance === null || axiosInstance === undefined) {
             axiosInstance = axios.create();

--- a/src/httpclient/axios/AxiosHttpClient.ts
+++ b/src/httpclient/axios/AxiosHttpClient.ts
@@ -7,53 +7,69 @@ import {AxiosHttpClientPromise} from "./AxiosHttpClientPromise";
 export class AxiosHttpClient implements HttpClient
 {
     private axiosInstance: AxiosInstance;
+    private withCredentials: boolean;
 
     constructor()
     constructor(axiosInstance?: AxiosInstance) {
         if (axiosInstance === null || axiosInstance === undefined) {
             axiosInstance = axios.create();
-            axiosInstance.defaults.headers['Accept'] = 'application/vnd.api+json';
-            axiosInstance.defaults.headers['Content-type'] = 'application/vnd.api+json';
         }
         this.axiosInstance = axiosInstance;
     }
 
-    setBaseUrl(baseUrl: string): void
+    setWithCredentials(withCredentials: boolean): void
     {
-        this.axiosInstance.defaults.baseURL = baseUrl;
-    }
-
-    setWithCredentials(withCredientials: boolean): void
-    {
-        this.axiosInstance.defaults.withCredentials = withCredientials;
+      this.withCredentials = withCredentials;
     }
 
     get(url: string): HttpClientPromise {
-        return new AxiosHttpClientPromise(this.axiosInstance.get(url));
+        return new AxiosHttpClientPromise(
+          this.axiosInstance.get(url, this.config)
+        );
     }
 
     delete(url: string): HttpClientPromise {
-        return new AxiosHttpClientPromise(this.axiosInstance.delete(url));
+        return new AxiosHttpClientPromise(
+          this.axiosInstance.delete(url, this.config)
+        );
     }
 
     head(url: string): HttpClientPromise {
-        return new AxiosHttpClientPromise(this.axiosInstance.head(url));
+        return new AxiosHttpClientPromise(
+          this.axiosInstance.head(url, this.config)
+        );
     }
 
     post(url: string, data?: any): HttpClientPromise {
-        return new AxiosHttpClientPromise(this.axiosInstance.post(url, data));
+        return new AxiosHttpClientPromise(
+          this.axiosInstance.post(url, data, this.config)
+        );
     }
 
     put(url: string, data?: any): HttpClientPromise {
-        return new AxiosHttpClientPromise(this.axiosInstance.put(url, data));
+        return new AxiosHttpClientPromise(
+          this.axiosInstance.put(url, data, this.config)
+        );
     }
 
     patch(url: string, data?: any): HttpClientPromise {
-        return new AxiosHttpClientPromise(this.axiosInstance.patch(url, data));
+        return new AxiosHttpClientPromise(
+          this.axiosInstance.patch(url, data, this.config)
+        );
     }
 
     public getImplementingClient(): AxiosInstance
     {
         return this.axiosInstance;
+    }
+
+    private get config (): AxiosRequestConfig {
+      return {
+        withCredentials: this.withCredentials,
+        headers: {
+          'Accept': 'application/vnd.api+json',
+          'Content-type': 'application/vnd.api+json',
+        }
+      }
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,9 @@ export { SortDirection } from "./SortDirection";
 export { HttpClient } from "./httpclient/HttpClient";
 export { HttpClientPromise } from "./httpclient/HttpClientPromise";
 export { HttpClientResponse } from "./httpclient/HttpClientResponse";
+export { AxiosHttpClient } from "./httpclient/axios/AxiosHttpClient";
+export { AxiosHttpClientPromise } from "./httpclient/axios/AxiosHttpClientPromise";
+export { AxiosHttpClientResponse } from "./httpclient/axios/AxiosHttpClientResponse";
 
 /**
  * relation

--- a/src/relation/Relation.ts
+++ b/src/relation/Relation.ts
@@ -31,6 +31,11 @@ export class Relation<R extends Model = Model>
         return this.relatedType;
     }
 
+    public getReferringType(): typeof Model
+    {
+        return this.getReferringObject().constructor;
+    }
+
     public getReferringObject(): Model
     {
         if (!this.referringObject) {

--- a/src/relation/ToManyRelation.ts
+++ b/src/relation/ToManyRelation.ts
@@ -9,37 +9,37 @@ import {Model} from "../Model";
 export class ToManyRelation<M extends Model = Model, R extends Model = Model> extends Relation<R> implements QueryMethods<M, PluralResponse<M>>
 {
     get(page?: number): Promise<PluralResponse<M>> {
-        return <Promise<PluralResponse<M>>> new Builder(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
+        return <Promise<PluralResponse<M>>> new Builder(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId())
             .get(page);
     }
 
     first(): Promise<SingularResponse<M>> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId())
             .first();
     }
 
     find(id: string | number): Promise<SingularResponse<M>> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId())
             .find(id);
     }
 
     where(attribute: string, value: string): Builder<M> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId())
             .where(attribute, value);
     }
 
     with(value: any): Builder<M> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId())
             .with(value);
     }
 
     public orderBy(attribute: string, direction?: SortDirection|string): Builder<M> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId())
             .orderBy(attribute, direction);
     }
 
     option(queryParameter: string, value: string): Builder<M> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId())
             .option(queryParameter, value);
     }
 }

--- a/src/relation/ToManyRelation.ts
+++ b/src/relation/ToManyRelation.ts
@@ -9,37 +9,37 @@ import {Model} from "../Model";
 export class ToManyRelation<M extends Model = Model, R extends Model = Model> extends Relation<R> implements QueryMethods<M, PluralResponse<M>>
 {
     get(page?: number): Promise<PluralResponse<M>> {
-        return <Promise<PluralResponse<M>>> new Builder(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+        return <Promise<PluralResponse<M>>> new Builder(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
             .get(page);
     }
 
     first(): Promise<SingularResponse<M>> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
             .first();
     }
 
     find(id: string | number): Promise<SingularResponse<M>> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
             .find(id);
     }
 
     where(attribute: string, value: string): Builder<M> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
             .where(attribute, value);
     }
 
     with(value: any): Builder<M> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
             .with(value);
     }
 
     public orderBy(attribute: string, direction?: SortDirection|string): Builder<M> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
             .orderBy(attribute, direction);
     }
 
     option(queryParameter: string, value: string): Builder<M> {
-        return new Builder<M>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId())
+        return new Builder<M>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId())
             .option(queryParameter, value);
     }
 }

--- a/src/relation/ToOneRelation.ts
+++ b/src/relation/ToOneRelation.ts
@@ -9,37 +9,37 @@ import {Model} from "../Model";
 export class ToOneRelation<M extends Model = Model, R extends Model = Model> extends Relation<R> implements QueryMethods<M, SingularResponse<M>>
 {
     get(page?: number): Promise<SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .get(page);
     }
 
     first(): Promise<SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .first();
     }
 
     find(id: string | number): Promise<SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .find(id);
     }
 
     where(attribute: string, value: string): Builder<M, SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .where(attribute, value);
     }
 
     with(value: any): Builder<M, SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .with(value);
     }
 
     orderBy(attribute: string, direction?: SortDirection|string): Builder<M, SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .orderBy(attribute, direction);
     }
 
     option(queryParameter: string, value: string): Builder<M, SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringObject().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
             .option(queryParameter, value);
     }
 }

--- a/src/relation/ToOneRelation.ts
+++ b/src/relation/ToOneRelation.ts
@@ -1,5 +1,4 @@
 import {Relation} from "./Relation";
-import {PluralResponse} from "../response/PluralResponse";
 import {Builder} from "../Builder";
 import {SingularResponse} from "../response/SingularResponse";
 import {QueryMethods} from "../QueryMethods";
@@ -9,37 +8,37 @@ import {Model} from "../Model";
 export class ToOneRelation<M extends Model = Model, R extends Model = Model> extends Relation<R> implements QueryMethods<M, SingularResponse<M>>
 {
     get(page?: number): Promise<SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId(), true)
             .get(page);
     }
 
     first(): Promise<SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId(), true)
             .first();
     }
 
     find(id: string | number): Promise<SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId(), true)
             .find(id);
     }
 
     where(attribute: string, value: string): Builder<M, SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId(), true)
             .where(attribute, value);
     }
 
     with(value: any): Builder<M, SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId(), true)
             .with(value);
     }
 
     orderBy(attribute: string, direction?: SortDirection|string): Builder<M, SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId(), true)
             .orderBy(attribute, direction);
     }
 
     option(queryParameter: string, value: string): Builder<M, SingularResponse<M>> {
-        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().getJsonApiType(), this.getReferringObject().getApiId(), true)
+        return new Builder<M, SingularResponse<M>>(this.getType(), this.getName(), this.getReferringType().effectiveJsonApiType, this.getReferringObject().getApiId(), true)
             .option(queryParameter, value);
     }
 }

--- a/tests/Model.test.ts
+++ b/tests/Model.test.ts
@@ -36,7 +36,7 @@ describe('Model', () => {
         class Foo extends Model {}
 
         it('throws an Error', () => {
-          expect(() => { Foo.getJsonApiType() }).to.throw();
+          expect(() => { Foo.effectiveJsonApiType }).to.throw();
         });
       });
 
@@ -46,7 +46,7 @@ describe('Model', () => {
         }
 
         it('returns jsonApiType', () => {
-          expect(Foo.getJsonApiType()).to.eq('foos');
+          expect(Foo.effectiveJsonApiType).to.eq('foos');
         });
       });
     });

--- a/tests/Model.test.ts
+++ b/tests/Model.test.ts
@@ -68,6 +68,16 @@ describe('Model', () => {
         it('returns jsonApiBaseUrl', () => {
           expect(Foo.effectiveJsonApiBaseUrl).to.eq('http://coloquent.app/api');
         });
+
+        describe('when jsonApiBaseUrl having trailing "/"', () => {
+          class Foo extends Model {
+            static jsonApiBaseUrl = 'http://coloquent.app/api/';
+          }
+
+          it('returns jsonApiBaseUrl without trailing "/"', () => {
+            expect(Foo.effectiveJsonApiBaseUrl).to.eq('http://coloquent.app/api');
+          });
+        });
       });
     });
 
@@ -92,6 +102,18 @@ describe('Model', () => {
 
         it('returns URL with endpoint', () => {
           expect(Foo.getJsonApiUrl()).to.eq('http://coloquent.app/api/custom-endpoint-foo')
+        });
+
+        describe('when endpoint having no heading "/"', () => {
+          class Foo extends Model {
+            static jsonApiBaseUrl = 'http://coloquent.app/api';
+            static jsonApiType = 'foos';
+            static endpoint = 'custom-endpoint-foo';
+          }
+
+          it('returns URL with endpoint', () => {
+            expect(Foo.getJsonApiUrl()).to.eq('http://coloquent.app/api/custom-endpoint-foo')
+          });
         });
       });
     });

--- a/tests/Model.test.ts
+++ b/tests/Model.test.ts
@@ -72,14 +72,6 @@ describe('Model', () => {
     });
 
     describe('getJsonApiUrl', () => {
-      describe('without static jsonApiBaseUrl', () => {
-        class Foo extends Model {}
-
-        it('throws an Error', () => {
-          expect(() => { Foo.getJsonApiUrl() }).to.throw();
-        });
-      });
-
       describe('with static jsonApiBaseUrl and jsonApiType', () => {
         class Foo extends Model {
           static jsonApiBaseUrl = 'http://coloquent.app/api';

--- a/tests/Model.test.ts
+++ b/tests/Model.test.ts
@@ -56,7 +56,7 @@ describe('Model', () => {
         class Foo extends Model {}
 
         it('throws an Error', () => {
-          expect(() => { Foo.getJsonApiBaseUrl() }).to.throw();
+          expect(() => { Foo.effectiveJsonApiBaseUrl }).to.throw();
         });
       });
 
@@ -66,7 +66,7 @@ describe('Model', () => {
         }
 
         it('returns jsonApiBaseUrl', () => {
-          expect(Foo.getJsonApiBaseUrl()).to.eq('http://coloquent.app/api');
+          expect(Foo.effectiveJsonApiBaseUrl).to.eq('http://coloquent.app/api');
         });
       });
     });

--- a/tests/Model.test.ts
+++ b/tests/Model.test.ts
@@ -8,13 +8,13 @@ describe('Model', () => {
         class Foo extends Model {}
 
         it('returns a new AxiosHttpClient', () => {
-          expect(Foo.getHttpClient()).to.be.an.instanceof(AxiosHttpClient);
+          expect(Foo.effectiveHttpClient).to.be.an.instanceof(AxiosHttpClient);
         });
 
         it('memoizes the HttpClient', () => {
-          const httpClient = Foo.getHttpClient()
+          const httpClient = Foo.effectiveHttpClient
 
-          expect(Foo.getHttpClient()).to.eql(httpClient);
+          expect(Foo.effectiveHttpClient).to.eql(httpClient);
         });
       });
 
@@ -26,7 +26,7 @@ describe('Model', () => {
         }
 
         it('returns the httpClient', () => {
-          expect(Foo.getHttpClient()).to.eql(httpClient)
+          expect(Foo.effectiveHttpClient).to.eql(httpClient)
         });
       });
     });

--- a/tests/Model.test.ts
+++ b/tests/Model.test.ts
@@ -1,0 +1,107 @@
+import {expect} from 'chai';
+import {AxiosHttpClient, Model} from "../dist";
+
+describe('Model', () => {
+  describe('static', () => {
+    describe('getHttpClient', () => {
+      describe('without static httpClient', () => {
+        class Foo extends Model {}
+
+        it('returns a new AxiosHttpClient', () => {
+          expect(Foo.getHttpClient()).to.be.an.instanceof(AxiosHttpClient);
+        });
+
+        it('memoizes the HttpClient', () => {
+          const httpClient = Foo.getHttpClient()
+
+          expect(Foo.getHttpClient()).to.eql(httpClient);
+        });
+      });
+
+      describe('with static httpClient', () => {
+        const httpClient = new AxiosHttpClient()
+
+        class Foo extends Model {
+          static httpClient = httpClient
+        }
+
+        it('returns the httpClient', () => {
+          expect(Foo.getHttpClient()).to.eql(httpClient)
+        });
+      });
+    });
+
+    describe('getJsonApiType', () => {
+      describe('without static jsonApiType', () => {
+        class Foo extends Model {}
+
+        it('throws an Error', () => {
+          expect(() => { Foo.getJsonApiType() }).to.throw();
+        });
+      });
+
+      describe('with static jsonApiType', () => {
+        class Foo extends Model {
+          static jsonApiType = 'foos'
+        }
+
+        it('returns jsonApiType', () => {
+          expect(Foo.getJsonApiType()).to.eq('foos');
+        });
+      });
+    });
+
+    describe('getJsonApiBaseUrl', () => {
+      describe('without static jsonApiType', () => {
+        class Foo extends Model {}
+
+        it('throws an Error', () => {
+          expect(() => { Foo.getJsonApiBaseUrl() }).to.throw();
+        });
+      });
+
+      describe('with static jsonApiBaseUrl', () => {
+        class Foo extends Model {
+          static jsonApiBaseUrl = 'http://coloquent.app/api';
+        }
+
+        it('returns jsonApiBaseUrl', () => {
+          expect(Foo.getJsonApiBaseUrl()).to.eq('http://coloquent.app/api');
+        });
+      });
+    });
+
+    describe('getJsonApiUrl', () => {
+      describe('without static jsonApiBaseUrl', () => {
+        class Foo extends Model {}
+
+        it('throws an Error', () => {
+          expect(() => { Foo.getJsonApiUrl() }).to.throw();
+        });
+      });
+
+      describe('with static jsonApiBaseUrl and jsonApiType', () => {
+        class Foo extends Model {
+          static jsonApiBaseUrl = 'http://coloquent.app/api';
+          static jsonApiType = 'foos';
+        }
+
+        it('returns URL with jsonApiType as endpoint', () => {
+          expect(Foo.getJsonApiUrl()).to.eq('http://coloquent.app/api/foos')
+        });
+      });
+
+      describe('with static jsonApiBaseUrl and jsonApiType and endpoint', () => {
+        class Foo extends Model {
+          static jsonApiBaseUrl = 'http://coloquent.app/api';
+          static jsonApiType = 'foos';
+          static endpoint = '/custom-endpoint-foo';
+        }
+
+        it('returns URL with endpoint', () => {
+          expect(Foo.getJsonApiUrl()).to.eq('http://coloquent.app/api/custom-endpoint-foo')
+        });
+      });
+    });
+  });
+});

--- a/tests/Model.test.ts
+++ b/tests/Model.test.ts
@@ -3,7 +3,7 @@ import {AxiosHttpClient, Model} from "../dist";
 
 describe('Model', () => {
   describe('static', () => {
-    describe('getHttpClient', () => {
+    describe('effectiveHttpClient', () => {
       describe('without static httpClient', () => {
         class Foo extends Model {}
 
@@ -31,7 +31,7 @@ describe('Model', () => {
       });
     });
 
-    describe('getJsonApiType', () => {
+    describe('effectiveJsonApiType', () => {
       describe('without static jsonApiType', () => {
         class Foo extends Model {}
 
@@ -51,7 +51,7 @@ describe('Model', () => {
       });
     });
 
-    describe('getJsonApiBaseUrl', () => {
+    describe('effectiveJsonApiBaseUrl', () => {
       describe('without static jsonApiType', () => {
         class Foo extends Model {}
 

--- a/tests/Relation.test.ts
+++ b/tests/Relation.test.ts
@@ -33,7 +33,7 @@ describe('Relation', () => {
 
         moxios.wait(() => {
             let request = moxios.requests.mostRecent();
-            assert.equal(request.url.split('?')[0], model.getJsonApiBaseUrl()+'heros/friends');
+            assert.equal(request.url.split('?')[0], model.getJsonApiBaseUrl()+'/heros/friends');
             done();
         });
     });
@@ -47,7 +47,7 @@ describe('Relation', () => {
 
         moxios.wait(() => {
             let request = moxios.requests.mostRecent();
-            assert.equal(request.url.split('?')[0], model.getJsonApiBaseUrl()+'heros/superman/friends');
+            assert.equal(request.url.split('?')[0], model.getJsonApiBaseUrl()+'/heros/superman/friends');
             done();
         });
     });
@@ -61,7 +61,7 @@ describe('Relation', () => {
 
         moxios.wait(() => {
             let request = moxios.requests.mostRecent();
-            assert.equal(request.url.split('?')[0], model.getJsonApiBaseUrl()+'heros/superman/rival');
+            assert.equal(request.url.split('?')[0], model.getJsonApiBaseUrl()+'/heros/superman/rival');
             done();
         });
     });

--- a/tests/model1/Model.test.ts
+++ b/tests/model1/Model.test.ts
@@ -204,7 +204,7 @@ describe('Model1', () => {
     });
 
     it('should allow a header to be set', (done) => {
-        let httpClient: AxiosInstance = Hero.getHttpClient().getImplementingClient();
+        let httpClient: AxiosInstance = Hero.effectiveHttpClient.getImplementingClient();
         httpClient.defaults.headers.authentication = 'someAuthenticationHeader5636rt3';
         Hero.find('1');
 

--- a/tests/model1/Model.test.ts
+++ b/tests/model1/Model.test.ts
@@ -26,7 +26,7 @@ describe('Model1', () => {
         expect(superHero.getJsonApiType()).to.equal('heros');
 
         /** @see BaseModel */
-        expect(superHero.getJsonApiBaseUrl()).to.equal('http://coloquent.app/api/');
+        expect(superHero.getJsonApiBaseUrl()).to.equal('http://coloquent.app/api');
     });
 
     it('should have an orderBy method', (done) => {

--- a/tests/model1/dummy/BaseModel.ts
+++ b/tests/model1/dummy/BaseModel.ts
@@ -9,7 +9,7 @@ export abstract class BaseModel extends Model {
 
     constructor() {
         super();
-        moxios.install((<AxiosInstance> BaseModel.getHttpClient().getImplementingClient()));
+        moxios.install((<AxiosInstance> BaseModel.effectiveHttpClient.getImplementingClient()));
     }
 
     public static setPaginationStrategy(paginationStrategy: PaginationStrategy): void

--- a/tests/model1/dummy/BaseModel.ts
+++ b/tests/model1/dummy/BaseModel.ts
@@ -5,13 +5,11 @@ import {Model} from "../../../dist";
 import {PaginationStrategy} from "../../../dist";
 
 export abstract class BaseModel extends Model {
+    protected static jsonApiBaseUrl = 'http://coloquent.app/api/';
+
     constructor() {
         super();
         moxios.install((<AxiosInstance> BaseModel.getHttpClient().getImplementingClient()));
-    }
-
-    getJsonApiBaseUrl(): string {
-        return 'http://coloquent.app/api/';
     }
 
     public static setPaginationStrategy(paginationStrategy: PaginationStrategy): void

--- a/tests/model1/dummy/Hero.ts
+++ b/tests/model1/dummy/Hero.ts
@@ -3,7 +3,7 @@ import {ToManyRelation, ToOneRelation} from "../../../dist";
 
 export class Hero extends BaseModel
 {
-    protected jsonApiType = 'heros';
+    protected static jsonApiType = 'heros';
 
     public friends(): ToManyRelation
     {

--- a/tests/model2/Model.test.ts
+++ b/tests/model2/Model.test.ts
@@ -204,7 +204,7 @@ describe('Model2', () => {
     });
 
     it('should allow a header to be set', (done) => {
-        let httpClient: AxiosInstance = Hero.getHttpClient().getImplementingClient();
+        let httpClient: AxiosInstance = Hero.effectiveHttpClient.getImplementingClient();
         httpClient.defaults.headers.authentication = 'someAuthenticationHeader5636rt3';
         Hero.find('1');
 

--- a/tests/model2/Model.test.ts
+++ b/tests/model2/Model.test.ts
@@ -26,7 +26,7 @@ describe('Model2', () => {
         expect(superHero.getJsonApiType()).to.equal('heros');
 
         /** @see BaseModel */
-        expect(superHero.getJsonApiBaseUrl()).to.equal('http://coloquent.app/api/');
+        expect(superHero.getJsonApiBaseUrl()).to.equal('http://coloquent.app/api');
     });
 
     it('should have an orderBy method', (done) => {

--- a/tests/model2/Model.test.ts
+++ b/tests/model2/Model.test.ts
@@ -218,7 +218,7 @@ describe('Model2', () => {
             done();
         });
     });
-    
+
     it('fresh method should reload the resource data from the backend', (done) => {
         const responseData = {
             response: {
@@ -393,7 +393,7 @@ describe('Model2', () => {
 
     it('fresh method should return \'undefined\' when model does not have an ID', (done) => {
         let hero = new Hero();
-        
+
         hero.setName('Bob');
 
         hero
@@ -402,6 +402,6 @@ describe('Model2', () => {
                 assert.equal(antihero, undefined);
                 done();
             })
-            .catch(error => done(error)); 
+            .catch(error => done(error));
     });
 });

--- a/tests/model2/dummy/BaseModel.ts
+++ b/tests/model2/dummy/BaseModel.ts
@@ -3,12 +3,10 @@ import * as moxios from 'moxios';
 import {Model} from "../../../dist";
 
 export abstract class BaseModel extends Model {
+    protected static jsonApiBaseUrl = 'http://coloquent.app/api/';
+
     constructor() {
         super();
         moxios.install((<AxiosInstance> BaseModel.getHttpClient().getImplementingClient()));
-    }
-
-    getJsonApiBaseUrl(): string {
-        return 'http://coloquent.app/api/';
     }
 }

--- a/tests/model2/dummy/BaseModel.ts
+++ b/tests/model2/dummy/BaseModel.ts
@@ -7,6 +7,6 @@ export abstract class BaseModel extends Model {
 
     constructor() {
         super();
-        moxios.install((<AxiosInstance> BaseModel.getHttpClient().getImplementingClient()));
+        moxios.install((<AxiosInstance> BaseModel.effectiveHttpClient.getImplementingClient()));
     }
 }

--- a/tests/model2/dummy/Hero.ts
+++ b/tests/model2/dummy/Hero.ts
@@ -2,9 +2,9 @@ import {BaseModel} from './BaseModel';
 import {ToManyRelation, ToOneRelation} from "../../../dist";
 
 export class Hero extends BaseModel {
-    protected jsonApiType = 'heros';
+    protected static jsonApiType = 'heros';
 
-    public setName(name: string) 
+    public setName(name: string)
     {
         this.setAttribute('name', name);
     }

--- a/tests/model3/dummy/AntiHero.ts
+++ b/tests/model3/dummy/AntiHero.ts
@@ -4,7 +4,7 @@ import {Hero} from "./Hero";
 
 export class AntiHero extends BaseModel
 {
-    protected jsonApiType = 'anti-heroes';
+    protected static jsonApiType = 'anti-heroes';
 
     public heroes(): ToManyRelation
     {

--- a/tests/model3/dummy/BaseModel.ts
+++ b/tests/model3/dummy/BaseModel.ts
@@ -3,12 +3,10 @@ import * as moxios from 'moxios';
 import {Model} from "../../../dist";
 
 export abstract class BaseModel extends Model {
+    protected static jsonApiBaseUrl = 'http://coloquent.app/api/';
+
     constructor() {
         super();
         moxios.install((<AxiosInstance> BaseModel.getHttpClient().getImplementingClient()));
-    }
-
-    getJsonApiBaseUrl(): string {
-        return 'http://coloquent.app/api/';
     }
 }

--- a/tests/model3/dummy/BaseModel.ts
+++ b/tests/model3/dummy/BaseModel.ts
@@ -7,6 +7,6 @@ export abstract class BaseModel extends Model {
 
     constructor() {
         super();
-        moxios.install((<AxiosInstance> BaseModel.getHttpClient().getImplementingClient()));
+        moxios.install((<AxiosInstance> BaseModel.effectiveHttpClient.getImplementingClient()));
     }
 }

--- a/tests/model3/dummy/Hero.ts
+++ b/tests/model3/dummy/Hero.ts
@@ -4,7 +4,7 @@ import {AntiHero} from "./AntiHero";
 
 export class Hero extends BaseModel
 {
-    protected jsonApiType = 'heros';
+    protected static jsonApiType = 'heros';
 
     public antiHeroes(): ToManyRelation
     {


### PR DESCRIPTION
References:
- #96
- #91 
- #37

## Description

Allow the _Model_ `httpClient`, `jsonApiBaseUrl`, `jsonApiType` to be accessible without an instance using static accessor.

---

```ts
import { Model, AxiosHttpClient } from 'coloquent'
import axios from 'axios'

const customAxioInstance = axios.create(options);

class Artist extends Model {
  static jsonApiBaseUrl = 'http://www.app.com/api';
  static jsonApiType = 'artists';
  static httpClient = new AxiosHttpClient(customAxioInstance);
}

Artist.effectiveJsonApiBaseUrl
// "http://www.app.com/api"

Artist.effectiveJsonApiType
// "artists"

Artist.effectiveHttpClient
// customAxioInstance

Artist.getJsonApiUrl()
// "http://www.app.com/api/artists"
```
