### PR TITLE
Fixed constructor retrieval when using ES6 proxies

### DIFF
--- a/src/Model.ts
+++ b/src/Model.ts
@@ -540,6 +540,6 @@ export abstract class Model
     }
 
     private getConstructorOf(model: Model): typeof Model {
-        return Object.getPrototypeOf(this).constructor;
+        return Object.getPrototypeOf(model).constructor;
     }
 }


### PR DESCRIPTION
Same issue as #88, although this time is a bit deeper.

I've added two private methods to get the constructor of the current model or the one of another instance, different than the current one. This way it will be easier to get the constructor and also reduce repetitions